### PR TITLE
Events optimization

### DIFF
--- a/account/src/main/java/org/killbill/billing/account/dao/DefaultAccountDao.java
+++ b/account/src/main/java/org/killbill/billing/account/dao/DefaultAccountDao.java
@@ -56,7 +56,7 @@ import org.killbill.billing.util.entity.dao.EntityDaoBase;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
 import org.skife.jdbi.v2.IDBI;
@@ -73,13 +73,13 @@ public class DefaultAccountDao extends EntityDaoBase<AccountModelDao, Account, A
     private static final Logger log = LoggerFactory.getLogger(DefaultAccountDao.class);
 
     private final CacheController<Long, ImmutableAccountData> accountImmutableCacheController;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final InternalCallContextFactory internalCallContextFactory;
     private final Clock clock;
     private final AuditDao auditDao;
 
     @Inject
-    public DefaultAccountDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final PersistentBus eventBus, final Clock clock, final CacheControllerDispatcher cacheControllerDispatcher,
+    public DefaultAccountDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final BusOptimizer eventBus, final Clock clock, final CacheControllerDispatcher cacheControllerDispatcher,
                              final InternalCallContextFactory internalCallContextFactory, final NonEntityDao nonEntityDao, final AuditDao auditDao) {
         super(nonEntityDao, cacheControllerDispatcher, new EntitySqlDaoTransactionalJdbiWrapper(dbi, roDbi, clock, cacheControllerDispatcher, nonEntityDao, internalCallContextFactory), AccountSqlDao.class);
         this.accountImmutableCacheController = cacheControllerDispatcher.getCacheController(CacheType.ACCOUNT_IMMUTABLE);

--- a/account/src/test/java/org/killbill/billing/account/glue/TestAccountModule.java
+++ b/account/src/test/java/org/killbill/billing/account/glue/TestAccountModule.java
@@ -26,6 +26,7 @@ import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
 import org.killbill.billing.util.glue.CustomFieldModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.TagStoreModule;
 
 public class TestAccountModule extends DefaultAccountModule {
@@ -41,6 +42,7 @@ public class TestAccountModule extends DefaultAccountModule {
         install(new AuditModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new CustomFieldModule(configSource));
         install(new MockTenantModule(configSource));

--- a/api/src/main/java/org/killbill/billing/glue/InvoiceModule.java
+++ b/api/src/main/java/org/killbill/billing/glue/InvoiceModule.java
@@ -20,8 +20,6 @@ package org.killbill.billing.glue;
 
 public interface InvoiceModule {
 
-    static final String STATIC_CONFIG = "StaticConfig";
-
     public void installInvoiceUserApi();
 
     public void installInvoiceInternalApi();

--- a/beatrix/src/main/java/org/killbill/billing/beatrix/DefaultBeatrixService.java
+++ b/beatrix/src/main/java/org/killbill/billing/beatrix/DefaultBeatrixService.java
@@ -24,16 +24,17 @@ import org.killbill.billing.beatrix.bus.api.BeatrixService;
 import org.killbill.billing.beatrix.extbus.BeatrixListener;
 import org.killbill.billing.platform.api.LifecycleHandlerType;
 import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus;
 
 public class DefaultBeatrixService implements BeatrixService {
 
 
     private final BeatrixListener beatrixListener;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
 
     @Inject
-    public DefaultBeatrixService(final PersistentBus eventBus, final BeatrixListener beatrixListener) {
+    public DefaultBeatrixService(final BusOptimizer eventBus, final BeatrixListener beatrixListener) {
         this.eventBus = eventBus;
         this.beatrixListener = beatrixListener;
     }

--- a/beatrix/src/main/java/org/killbill/billing/beatrix/DefaultBeatrixService.java
+++ b/beatrix/src/main/java/org/killbill/billing/beatrix/DefaultBeatrixService.java
@@ -31,10 +31,10 @@ public class DefaultBeatrixService implements BeatrixService {
 
 
     private final BeatrixListener beatrixListener;
-    private final BusOptimizer eventBus;
+    private final PersistentBus eventBus;
 
     @Inject
-    public DefaultBeatrixService(final BusOptimizer eventBus, final BeatrixListener beatrixListener) {
+    public DefaultBeatrixService(final PersistentBus eventBus, final BeatrixListener beatrixListener) {
         this.eventBus = eventBus;
         this.beatrixListener = beatrixListener;
     }

--- a/beatrix/src/main/java/org/killbill/billing/beatrix/extbus/BeatrixListener.java
+++ b/beatrix/src/main/java/org/killbill/billing/beatrix/extbus/BeatrixListener.java
@@ -105,6 +105,7 @@ public class BeatrixListener {
     @AllowConcurrentEvents
     @Subscribe
     public void handleAllInternalKillbillEvents(final BusInternalEvent event) {
+        // No BusDispatcherOptimizer logic on purpose
         final InternalCallContext internalContext = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "BeatrixListener", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
         try {
             final BusEvent externalEvent = computeExtBusEventEntryFromBusInternalEvent(event, internalContext);

--- a/beatrix/src/main/java/org/killbill/billing/beatrix/extbus/BeatrixListener.java
+++ b/beatrix/src/main/java/org/killbill/billing/beatrix/extbus/BeatrixListener.java
@@ -86,6 +86,7 @@ public class BeatrixListener {
 
     private static final Logger log = LoggerFactory.getLogger(BeatrixListener.class);
 
+    // External bus: Do not use BusOptimizer
     private final PersistentBus externalBus;
     private final InternalCallContextFactory internalCallContextFactory;
 

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModule.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModule.java
@@ -58,6 +58,7 @@ import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
 import org.killbill.billing.util.glue.CustomFieldModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.ExportModule;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.killbill.billing.util.glue.KillBillShiroModule;
@@ -97,6 +98,7 @@ public class BeatrixIntegrationModule extends KillBillModule {
         install(new GuicyKillbillTestWithEmbeddedDBModule(true, configSource, clock));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new TagStoreModule(configSource));
         install(new CustomFieldModule(configSource));

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModuleNoDB.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/BeatrixIntegrationModuleNoDB.java
@@ -22,9 +22,14 @@ import org.killbill.billing.mock.glue.MockAccountModule;
 import org.killbill.billing.mock.glue.MockNonEntityDaoModule;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
+import org.killbill.billing.util.config.definition.EventConfig;
+import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.killbill.clock.ClockMock;
+import org.skife.config.ConfigurationObjectFactory;
 
+import com.google.inject.name.Names;
 import com.google.inject.util.Providers;
 
 public class BeatrixIntegrationModuleNoDB extends KillBillModule {
@@ -39,9 +44,11 @@ public class BeatrixIntegrationModuleNoDB extends KillBillModule {
     @Override
     protected void configure() {
         install(new GuicyKillbillTestNoDBModule(configSource, clock));
-
         install(new MockNonEntityDaoModule(configSource));
         install(new MockAccountModule(configSource));
         bind(CacheControllerDispatcher.class).toProvider(Providers.<CacheControllerDispatcher>of(null));
+        final EventConfig eventConfig = new ConfigurationObjectFactory(skifeConfigSource).build(EventConfig.class);
+        bind(EventConfig.class).toInstance(eventConfig);
+
     }
 }

--- a/catalog/src/test/java/org/killbill/billing/catalog/glue/TestCatalogModule.java
+++ b/catalog/src/test/java/org/killbill/billing/catalog/glue/TestCatalogModule.java
@@ -25,6 +25,7 @@ import org.killbill.billing.mock.glue.MockTenantModule;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 
 public class TestCatalogModule extends CatalogModule {
 
@@ -38,6 +39,7 @@ public class TestCatalogModule extends CatalogModule {
         install(new MockNonEntityDaoModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new MockTenantModule(configSource));
         install(new MockAccountModule(configSource));
     }

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/DefaultEntitlementService.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/DefaultEntitlementService.java
@@ -43,8 +43,8 @@ import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.BusEvent;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationQueue;
@@ -66,7 +66,7 @@ public class DefaultEntitlementService implements EntitlementService {
 
     private final EntitlementInternalApi entitlementInternalApi;
     private final BlockingStateDao blockingStateDao;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final NotificationQueueService notificationQueueService;
     private final EntitlementUtils entitlementUtils;
     private final InternalCallContextFactory internalCallContextFactory;
@@ -76,7 +76,7 @@ public class DefaultEntitlementService implements EntitlementService {
     @Inject
     public DefaultEntitlementService(final EntitlementInternalApi entitlementInternalApi,
                                      final BlockingStateDao blockingStateDao,
-                                     final PersistentBus eventBus,
+                                     final BusOptimizer eventBus,
                                      final NotificationQueueService notificationQueueService,
                                      final EntitlementUtils entitlementUtils,
                                      final InternalCallContextFactory internalCallContextFactory) {

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/DefaultEntitlementApi.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/DefaultEntitlementApi.java
@@ -41,7 +41,6 @@ import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.catalog.api.CatalogApiException;
 import org.killbill.billing.catalog.api.CatalogInternalApi;
 import org.killbill.billing.catalog.api.ProductCategory;
-import org.killbill.billing.catalog.api.StaticCatalog;
 import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.entitlement.AccountEventsStreams;
 import org.killbill.billing.entitlement.EventsStream;
@@ -69,7 +68,7 @@ import org.killbill.billing.subscription.api.user.SubscriptionBaseBundle;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 
@@ -85,7 +84,6 @@ import static org.killbill.billing.entitlement.logging.EntitlementLoggingHelper.
 import static org.killbill.billing.entitlement.logging.EntitlementLoggingHelper.logTransferEntitlement;
 
 public class DefaultEntitlementApi extends DefaultEntitlementApiBase implements EntitlementApi {
-
 
     public static final String ENT_STATE_START = "ENT_STARTED";
     public static final String ENT_STATE_BLOCKED = "ENT_BLOCKED";
@@ -107,7 +105,7 @@ public class DefaultEntitlementApi extends DefaultEntitlementApiBase implements 
     private final CatalogInternalApi catalogInternalApi;
 
     @Inject
-    public DefaultEntitlementApi(final PersistentBus eventBus, final InternalCallContextFactory internalCallContextFactory,
+    public DefaultEntitlementApi(final BusOptimizer eventBus, final InternalCallContextFactory internalCallContextFactory,
                                  final SubscriptionBaseTransferApi subscriptionTransferApi, final SubscriptionBaseInternalApi subscriptionInternalApi,
                                  final AccountInternalApi accountApi, final BlockingStateDao blockingStateDao, final Clock clock,
                                  final BlockingChecker checker, final NotificationQueueService notificationQueueService,

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementApiBase.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementApiBase.java
@@ -34,7 +34,6 @@ import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.entitlement.AccountEntitlements;
 import org.killbill.billing.entitlement.AccountEventsStreams;
-import org.killbill.billing.entitlement.EntitlementService;
 import org.killbill.billing.entitlement.EventsStream;
 import org.killbill.billing.entitlement.api.BaseEntitlementWithAddOnsSpecifier;
 import org.killbill.billing.entitlement.api.BlockingState;
@@ -63,7 +62,7 @@ import org.killbill.billing.subscription.api.SubscriptionBase;
 import org.killbill.billing.subscription.api.SubscriptionBaseInternalApi;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.slf4j.Logger;
@@ -89,9 +88,9 @@ public class DefaultEntitlementApiBase {
     protected final NotificationQueueService notificationQueueService;
     protected final EntitlementPluginExecution pluginExecution;
     protected final SecurityApi securityApi;
-    protected final PersistentBus eventBus;
+    protected final BusOptimizer eventBus;
 
-    protected DefaultEntitlementApiBase(final PersistentBus eventBus,
+    protected DefaultEntitlementApiBase(final BusOptimizer eventBus,
                                         @Nullable final EntitlementApi entitlementApi, final EntitlementPluginExecution pluginExecution,
                                         final InternalCallContextFactory internalCallContextFactory,
                                         final SubscriptionBaseInternalApi subscriptionInternalApi,
@@ -147,7 +146,6 @@ public class DefaultEntitlementApiBase {
                                       blockingStateDao, subscriptionInternalApi, checker, notificationQueueService,
                                       entitlementUtils, dateHelper, clock, securityApi, tenantContext, internalCallContextFactory);
     }
-
 
     public void pause(final UUID bundleId, @Nullable final LocalDate localEffectiveDate, final Iterable<PluginProperty> properties, final InternalCallContext internalCallContext) throws EntitlementApiException {
 

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementInternalApi.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/api/svcs/DefaultEntitlementInternalApi.java
@@ -35,7 +35,6 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.callcontext.InternalCallContext;
-import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.BillingActionPolicy;
 import org.killbill.billing.entitlement.DefaultEntitlementService;
 import org.killbill.billing.entitlement.EntitlementInternalApi;
@@ -67,7 +66,7 @@ import org.killbill.billing.subscription.api.SubscriptionBaseInternalApi;
 import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationQueue;
@@ -82,7 +81,7 @@ public class DefaultEntitlementInternalApi extends DefaultEntitlementApiBase imp
     private final BlockingStateDao blockingStateDao;
 
     @Inject
-    public DefaultEntitlementInternalApi(final PersistentBus eventBus,
+    public DefaultEntitlementInternalApi(final BusOptimizer eventBus,
                                          final EntitlementApi entitlementApi, final EntitlementPluginExecution pluginExecution,
                                          final InternalCallContextFactory internalCallContextFactory,
                                          final SubscriptionBaseInternalApi subscriptionInternalApi,
@@ -92,7 +91,6 @@ public class DefaultEntitlementInternalApi extends DefaultEntitlementApiBase imp
         super(eventBus, entitlementApi, pluginExecution, internalCallContextFactory, subscriptionInternalApi, accountApi, blockingStateDao, clock, checker, notificationQueueService, eventsStreamBuilder, entitlementUtils, securityApi);
         this.blockingStateDao = blockingStateDao;
     }
-
 
     @Override
     public void cancel(final Iterable<Entitlement> entitlements, @Nullable final LocalDate effectiveDate, final BillingActionPolicy billingPolicy, final Iterable<PluginProperty> properties, final InternalCallContext internalCallContext) throws EntitlementApiException {

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/DefaultBlockingStateDao.java
@@ -60,8 +60,8 @@ import org.killbill.billing.util.entity.dao.EntityDaoBase;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.BusEvent;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
@@ -115,14 +115,14 @@ public class DefaultBlockingStateDao extends EntityDaoBase<BlockingStateModelDao
 
     private final Clock clock;
     private final NotificationQueueService notificationQueueService;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final CacheController<String, UUID> objectIdCacheController;
     private final NonEntityDao nonEntityDao;
     private final AuditDao auditDao;
 
     private final StatelessBlockingChecker statelessBlockingChecker = new StatelessBlockingChecker();
 
-    public DefaultBlockingStateDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final NotificationQueueService notificationQueueService, final PersistentBus eventBus,
+    public DefaultBlockingStateDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final NotificationQueueService notificationQueueService, final BusOptimizer eventBus,
                                    final CacheControllerDispatcher cacheControllerDispatcher, final NonEntityDao nonEntityDao, final AuditDao auditDao, final InternalCallContextFactory internalCallContextFactory) {
         super(nonEntityDao, cacheControllerDispatcher, new EntitySqlDaoTransactionalJdbiWrapper(dbi, roDbi, clock, cacheControllerDispatcher, nonEntityDao, internalCallContextFactory), BlockingStateSqlDao.class);
         this.clock = clock;

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/OptimizedProxyBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/OptimizedProxyBlockingStateDao.java
@@ -20,14 +20,12 @@ package org.killbill.billing.entitlement.dao;
 
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
 
 import javax.annotation.Nullable;
 
 import org.killbill.billing.account.api.ImmutableAccountData;
 import org.killbill.billing.callcontext.InternalTenantContext;
 import org.killbill.billing.catalog.api.ProductCategory;
-import org.killbill.billing.catalog.api.StaticCatalog;
 import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.entitlement.EventsStream;
 import org.killbill.billing.entitlement.api.BlockingState;
@@ -41,7 +39,7 @@ import org.killbill.billing.util.audit.dao.AuditDao;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.dao.NonEntityDao;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.jdbi.v2.IDBI;
@@ -51,7 +49,7 @@ import com.google.common.collect.ImmutableList;
 public class OptimizedProxyBlockingStateDao extends ProxyBlockingStateDao {
 
     public OptimizedProxyBlockingStateDao(final EventsStreamBuilder eventsStreamBuilder, final SubscriptionBaseInternalApi subscriptionBaseInternalApi,
-                                          final IDBI dbi, final IDBI roDbi, final Clock clock, final NotificationQueueService notificationQueueService, final PersistentBus eventBus,
+                                          final IDBI dbi, final IDBI roDbi, final Clock clock, final NotificationQueueService notificationQueueService, final BusOptimizer eventBus,
                                           final CacheControllerDispatcher cacheControllerDispatcher, final NonEntityDao nonEntityDao, final AuditDao auditDao, final InternalCallContextFactory internalCallContextFactory) {
         super(eventsStreamBuilder, subscriptionBaseInternalApi, dbi, roDbi, clock, notificationQueueService, eventBus, cacheControllerDispatcher, nonEntityDao, auditDao, internalCallContextFactory);
     }

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/dao/ProxyBlockingStateDao.java
@@ -54,7 +54,7 @@ import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.customfield.ShouldntHappenException;
 import org.killbill.billing.util.dao.NonEntityDao;
 import org.killbill.billing.util.entity.Pagination;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.jdbi.v2.IDBI;
@@ -179,7 +179,7 @@ public class ProxyBlockingStateDao implements BlockingStateDao {
 
     @Inject
     public ProxyBlockingStateDao(final EventsStreamBuilder eventsStreamBuilder, final SubscriptionBaseInternalApi subscriptionBaseInternalApi,
-                                 final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final NotificationQueueService notificationQueueService, final PersistentBus eventBus,
+                                 final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final NotificationQueueService notificationQueueService, final BusOptimizer eventBus,
                                  final CacheControllerDispatcher cacheControllerDispatcher, final NonEntityDao nonEntityDao, final AuditDao auditDao, final InternalCallContextFactory internalCallContextFactory) {
         this.eventsStreamBuilder = eventsStreamBuilder;
         this.subscriptionInternalApi = subscriptionBaseInternalApi;

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/engine/core/EventsStreamBuilder.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/engine/core/EventsStreamBuilder.java
@@ -66,7 +66,7 @@ import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.dao.NonEntityDao;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.jdbi.v2.IDBI;
@@ -99,7 +99,7 @@ public class EventsStreamBuilder {
                                @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi,
                                final Clock clock,
                                final NotificationQueueService notificationQueueService,
-                               final PersistentBus eventBus,
+                               final BusOptimizer eventBus,
                                final CacheControllerDispatcher cacheControllerDispatcher,
                                final NonEntityDao nonEntityDao,
                                final AuditDao auditDao,

--- a/entitlement/src/test/java/org/killbill/billing/entitlement/glue/TestEntitlementModule.java
+++ b/entitlement/src/test/java/org/killbill/billing/entitlement/glue/TestEntitlementModule.java
@@ -23,6 +23,7 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.KillBillShiroAopModule;
 import org.killbill.billing.util.glue.KillBillShiroModule;
 import org.killbill.billing.util.glue.SecurityModule;
@@ -42,6 +43,7 @@ public class TestEntitlementModule extends DefaultEntitlementModule {
         super.configure();
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new MockTenantModule(configSource));
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceDispatcher.java
@@ -99,7 +99,7 @@ import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.globallocker.LockerType;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
 import org.killbill.commons.locker.GlobalLock;
@@ -148,7 +148,7 @@ public class InvoiceDispatcher {
     private final InternalCallContextFactory internalCallContextFactory;
     private final InvoicePluginDispatcher invoicePluginDispatcher;
     private final GlobalLocker locker;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final Clock clock;
     private final NotificationQueueService notificationQueueService;
     private final InvoiceConfig invoiceConfig;
@@ -164,7 +164,7 @@ public class InvoiceDispatcher {
                              final InternalCallContextFactory internalCallContextFactory,
                              final InvoicePluginDispatcher invoicePluginDispatcher,
                              final GlobalLocker locker,
-                             final PersistentBus eventBus,
+                             final BusOptimizer eventBus,
                              final NotificationQueueService notificationQueueService,
                              final InvoiceConfig invoiceConfig,
                              final Clock clock,

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -42,6 +42,7 @@ import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
@@ -68,7 +69,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
     private final InternalCallContextFactory internalCallContextFactory;
     private final InvoiceInternalApi invoiceApi;
     private final RetryableSubscriber retryableSubscriber;
-    private final BusOptimizer busOptimizer;
+    private final BusDispatcherOptimizer busDispatcherOptimizer;
     private final SubscriberQueueHandler subscriberQueueHandler = new SubscriberQueueHandler();
 
     @Inject
@@ -77,13 +78,13 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                            final InvoiceDispatcher dispatcher,
                            final InvoiceInternalApi invoiceApi,
                            final NotificationQueueService notificationQueueService,
-                           final BusOptimizer busOptimizer,
+                           final BusDispatcherOptimizer busDispatcherOptimizer,
                            final Clock clock) {
         super(notificationQueueService);
         this.dispatcher = dispatcher;
         this.internalCallContextFactory = internalCallContextFactory;
         this.invoiceApi = invoiceApi;
-        this.busOptimizer = busOptimizer;
+        this.busDispatcherOptimizer = busDispatcherOptimizer;
 
         subscriberQueueHandler.subscribe(EffectiveSubscriptionInternalEvent.class,
                                          new SubscriberAction<EffectiveSubscriptionInternalEvent>() {
@@ -202,7 +203,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
 
 
     private void handleEvent(final BusInternalEvent event) {
-        if (busOptimizer.shouldDispatch(event)) {
+        if (busDispatcherOptimizer.shouldDispatch(event)) {
             retryableSubscriber.handleEvent(event);
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -27,9 +27,11 @@ import org.killbill.billing.account.api.AccountApiException;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.events.BlockingTransitionInternalEvent;
+import org.killbill.billing.events.BusInternalEvent;
 import org.killbill.billing.events.EffectiveSubscriptionInternalEvent;
 import org.killbill.billing.events.InvoiceCreationInternalEvent;
 import org.killbill.billing.events.RequestedSubscriptionInternalEvent;
+import org.killbill.billing.events.SubscriptionInternalEvent;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.invoice.api.InvoiceListenerService;
@@ -40,6 +42,7 @@ import org.killbill.billing.subscription.api.SubscriptionBaseTransitionType;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
@@ -65,6 +68,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
     private final InternalCallContextFactory internalCallContextFactory;
     private final InvoiceInternalApi invoiceApi;
     private final RetryableSubscriber retryableSubscriber;
+    private final BusOptimizer busOptimizer;
     private final SubscriberQueueHandler subscriberQueueHandler = new SubscriberQueueHandler();
 
     @Inject
@@ -73,11 +77,13 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                            final InvoiceDispatcher dispatcher,
                            final InvoiceInternalApi invoiceApi,
                            final NotificationQueueService notificationQueueService,
+                           final BusOptimizer busOptimizer,
                            final Clock clock) {
         super(notificationQueueService);
         this.dispatcher = dispatcher;
         this.internalCallContextFactory = internalCallContextFactory;
         this.invoiceApi = invoiceApi;
+        this.busOptimizer = busOptimizer;
 
         subscriberQueueHandler.subscribe(EffectiveSubscriptionInternalEvent.class,
                                          new SubscriberAction<EffectiveSubscriptionInternalEvent>() {
@@ -194,22 +200,29 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
         super.stop();
     }
 
+
+    private void handleEvent(final BusInternalEvent event) {
+        if (busOptimizer.shouldDispatch(event)) {
+            retryableSubscriber.handleEvent(event);
+        }
+    }
+
     @AllowConcurrentEvents
     @Subscribe
     public void handleSubscriptionTransition(final EffectiveSubscriptionInternalEvent event) {
-        retryableSubscriber.handleEvent(event);
+        handleEvent(event);
     }
 
     @AllowConcurrentEvents
     @Subscribe
     public void handleBlockingStateTransition(final BlockingTransitionInternalEvent event) {
-        retryableSubscriber.handleEvent(event);
+        handleEvent(event);
     }
 
     @AllowConcurrentEvents
     @Subscribe
     public void handleSubscriptionTransition(final RequestedSubscriptionInternalEvent event) {
-        retryableSubscriber.handleEvent(event);
+        handleEvent(event);
     }
 
     public void handleNextBillingDateEvent(final UUID subscriptionId, final DateTime eventDateTime, final boolean isRescheduled, final UUID userToken, final Long accountRecordId, final Long tenantRecordId) {
@@ -233,7 +246,7 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
     @AllowConcurrentEvents
     @Subscribe
     public void handleChildrenInvoiceCreationEvent(final InvoiceCreationInternalEvent event) {
-        retryableSubscriber.handleEvent(event);
+        handleEvent(event);
     }
 
     private boolean isChildrenAccountAndPaymentDelegated(final Account account) {
@@ -255,6 +268,6 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
     @AllowConcurrentEvents
     @Subscribe
     public void handleChildrenInvoiceAdjustmentEvent(final DefaultInvoiceAdjustmentEvent event) {
-        retryableSubscriber.handleEvent(event);
+        handleEvent(event);
     }
 }

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -31,7 +31,6 @@ import org.killbill.billing.events.BusInternalEvent;
 import org.killbill.billing.events.EffectiveSubscriptionInternalEvent;
 import org.killbill.billing.events.InvoiceCreationInternalEvent;
 import org.killbill.billing.events.RequestedSubscriptionInternalEvent;
-import org.killbill.billing.events.SubscriptionInternalEvent;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.invoice.api.InvoiceListenerService;

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceTagHandler.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceTagHandler.java
@@ -30,6 +30,7 @@ import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.killbill.clock.Clock;
@@ -55,7 +56,7 @@ public class InvoiceTagHandler extends RetryableService implements KillbillServi
 
     private final InvoiceDispatcher dispatcher;
     private final RetryableSubscriber retryableSubscriber;
-    private final BusOptimizer busOptimizer;
+    private final BusDispatcherOptimizer busDispatcherOptimizer;
 
     private final SubscriberQueueHandler subscriberQueueHandler = new SubscriberQueueHandler();
 
@@ -63,11 +64,11 @@ public class InvoiceTagHandler extends RetryableService implements KillbillServi
     public InvoiceTagHandler(final Clock clock,
                              final InvoiceDispatcher dispatcher,
                              final NotificationQueueService notificationQueueService,
-                             final BusOptimizer busOptimizer,
+                             final BusDispatcherOptimizer busDispatcherOptimizer,
                              final InternalCallContextFactory internalCallContextFactory) {
         super(notificationQueueService);
         this.dispatcher = dispatcher;
-        this.busOptimizer = busOptimizer;
+        this.busDispatcherOptimizer = busDispatcherOptimizer;
 
         final SubscriberAction<ControlTagDeletionInternalEvent> action = new SubscriberAction<ControlTagDeletionInternalEvent>() {
             @Override
@@ -101,7 +102,7 @@ public class InvoiceTagHandler extends RetryableService implements KillbillServi
     @AllowConcurrentEvents
     @Subscribe
     public void process_AUTO_INVOICING_OFF_removal(final ControlTagDeletionInternalEvent event) {
-        if (busOptimizer.shouldDispatch(event)) {
+        if (busDispatcherOptimizer.shouldDispatch(event)) {
             retryableSubscriber.handleEvent(event);
         }
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/DefaultInvoiceService.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/DefaultInvoiceService.java
@@ -19,6 +19,7 @@
 package org.killbill.billing.invoice.api;
 
 import org.killbill.billing.invoice.notification.ParentInvoiceCommitmentNotifier;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus;
 import org.killbill.billing.invoice.InvoiceListener;
 import org.killbill.billing.invoice.InvoiceTagHandler;
@@ -35,11 +36,11 @@ public class DefaultInvoiceService implements InvoiceService {
     private final NextBillingDateNotifier dateNotifier;
     private final InvoiceListener invoiceListener;
     private final InvoiceTagHandler tagHandler;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final ParentInvoiceCommitmentNotifier parentInvoiceNotifier;
 
     @Inject
-    public DefaultInvoiceService(final InvoiceListener invoiceListener, final InvoiceTagHandler tagHandler, final PersistentBus eventBus,
+    public DefaultInvoiceService(final InvoiceListener invoiceListener, final InvoiceTagHandler tagHandler, final BusOptimizer eventBus,
                                  final NextBillingDateNotifier dateNotifier, final ParentInvoiceCommitmentNotifier parentInvoiceNotifier) {
         this.invoiceListener = invoiceListener;
         this.tagHandler = tagHandler;

--- a/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/api/user/DefaultInvoiceUserApi.java
@@ -65,7 +65,6 @@ import org.killbill.billing.invoice.model.TaxInvoiceItem;
 import org.killbill.billing.invoice.template.HtmlInvoice;
 import org.killbill.billing.invoice.template.HtmlInvoiceGenerator;
 import org.killbill.billing.payment.api.PluginProperty;
-import org.killbill.billing.subscription.api.user.SubscriptionBaseApiException;
 import org.killbill.billing.tag.TagInternalApi;
 import org.killbill.billing.util.UUIDs;
 import org.killbill.billing.util.api.AuditLevel;
@@ -76,9 +75,9 @@ import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.entity.Pagination;
 import org.killbill.billing.util.entity.dao.DefaultPaginationHelper.SourcePaginationBuilder;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.killbill.billing.util.tag.Tag;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,7 +105,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     private final InvoiceApiHelper invoiceApiHelper;
     private final HtmlInvoiceGenerator generator;
     private final InternalCallContextFactory internalCallContextFactory;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
 
     private final CatalogInternalApi catalogInternalApi;
 
@@ -114,7 +113,7 @@ public class DefaultInvoiceUserApi implements InvoiceUserApi {
     public DefaultInvoiceUserApi(final InvoiceDao dao,
                                  final InvoiceDispatcher dispatcher,
                                  final AccountInternalApi accountUserApi,
-                                 final PersistentBus eventBus,
+                                 final BusOptimizer eventBus,
                                  final TagInternalApi tagApi,
                                  final InvoiceApiHelper invoiceApiHelper,
                                  final HtmlInvoiceGenerator generator,

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -24,7 +24,6 @@ import javax.inject.Named;
 
 import org.joda.time.Period;
 import org.killbill.billing.callcontext.InternalTenantContext;
-import org.killbill.billing.glue.InvoiceModule;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;

--- a/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/config/MultiTenantInvoiceConfig.java
@@ -29,6 +29,7 @@ import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;
 import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.TimeSpan;
 
 public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements InvoiceConfig {
@@ -37,7 +38,7 @@ public class MultiTenantInvoiceConfig extends MultiTenantConfigBase implements I
     private final InvoiceConfig staticConfig;
 
     @Inject
-    public MultiTenantInvoiceConfig(@Named(InvoiceModule.STATIC_CONFIG) final InvoiceConfig staticConfig, final CacheConfig cacheConfig) {
+    public MultiTenantInvoiceConfig(@Named(KillBillModule.STATIC_CONFIG) final InvoiceConfig staticConfig, final CacheConfig cacheConfig) {
         super(cacheConfig);
         this.staticConfig = staticConfig;
     }

--- a/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/dao/DefaultInvoiceDao.java
@@ -82,9 +82,9 @@ import org.killbill.billing.util.entity.dao.EntityDaoBase;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.tag.Tag;
 import org.killbill.bus.api.BusEvent;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
 import org.skife.jdbi.v2.IDBI;
@@ -124,7 +124,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                                                                                                                        InvoiceItemType.PARENT_SUMMARY);
 
     private final NextBillingDatePoster nextBillingDatePoster;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final InternalCallContextFactory internalCallContextFactory;
     private final InvoiceDaoHelper invoiceDaoHelper;
     private final CBADao cbaDao;
@@ -141,7 +141,7 @@ public class DefaultInvoiceDao extends EntityDaoBase<InvoiceModelDao, Invoice, I
                              final IDBI dbi,
                              @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi,
                              final NextBillingDatePoster nextBillingDatePoster,
-                             final PersistentBus eventBus,
+                             final BusOptimizer eventBus,
                              final Clock clock,
                              final CacheControllerDispatcher cacheControllerDispatcher,
                              final NonEntityDao nonEntityDao,

--- a/invoice/src/main/java/org/killbill/billing/invoice/glue/DefaultInvoiceModule.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/glue/DefaultInvoiceModule.java
@@ -90,7 +90,7 @@ public class DefaultInvoiceModule extends KillBillModule implements InvoiceModul
     }
 
     protected void installConfig(final InvoiceConfig staticInvoiceConfig) {
-        bind(InvoiceConfig.class).annotatedWith(Names.named(STATIC_CONFIG)).toInstance(staticInvoiceConfig);
+        bind(InvoiceConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(staticInvoiceConfig);
         bind(InvoiceConfig.class).to(MultiTenantInvoiceConfig.class).asEagerSingleton();
     }
 

--- a/invoice/src/test/java/org/killbill/billing/invoice/InvoiceTestSuiteWithEmbeddedDB.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/InvoiceTestSuiteWithEmbeddedDB.java
@@ -39,7 +39,7 @@ import org.killbill.billing.util.api.TagUserApi;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.dao.NonEntityDao;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.commons.locker.GlobalLocker;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.slf4j.Logger;
@@ -61,7 +61,7 @@ public abstract class InvoiceTestSuiteWithEmbeddedDB extends GuicyKillbillTestSu
     @Inject
     protected InvoiceService invoiceService;
     @Inject
-    protected PersistentBus bus;
+    protected BusOptimizer bus;
     @Inject
     protected CacheControllerDispatcher controllerDispatcher;
     @Inject

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcher.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceDispatcher.java
@@ -82,7 +82,7 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
         context = internalCallContextFactory.createInternalCallContext(account.getId(), callContext);
 
         dispatcher = new InvoiceDispatcher(generator, accountApi, billingApi, subscriptionApi, invoiceDao,
-                                           internalCallContextFactory,  invoicePluginDispatcher, locker, busService.getBus(),
+                                           internalCallContextFactory,  invoicePluginDispatcher, locker, bus,
                                            notificationQueueService, invoiceConfig, clock, invoiceOptimizer, parkedAccountsManager);
 
     }
@@ -106,7 +106,7 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
         final LocalDate target = internalCallContext.toLocalDate(effectiveDate);
 
         final InvoiceDispatcher dispatcher = new InvoiceDispatcher(generator, accountApi, billingApi, subscriptionApi, invoiceDao,
-                                                                   internalCallContextFactory, invoicePluginDispatcher, locker, busService.getBus(),
+                                                                   internalCallContextFactory, invoicePluginDispatcher, locker, bus,
                                                                    notificationQueueService, invoiceConfig, clock, invoiceOptimizer, parkedAccountsManager);
 
         Invoice invoice = dispatcher.processAccountFromNotificationOrBusEvent(accountId, target, new DryRunFutureDateArguments(), false, context);
@@ -149,7 +149,7 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
         final LocalDate target = internalCallContext.toLocalDate(effectiveDate);
 
         final InvoiceDispatcher dispatcher = new InvoiceDispatcher(generator, accountApi, billingApi, subscriptionApi, invoiceDao,
-                                                                   internalCallContextFactory, invoicePluginDispatcher, locker, busService.getBus(),
+                                                                   internalCallContextFactory, invoicePluginDispatcher, locker, bus,
                                                                    notificationQueueService, invoiceConfig, clock, invoiceOptimizer, parkedAccountsManager);
 
         // Verify initial tags state for account
@@ -300,7 +300,7 @@ public class TestInvoiceDispatcher extends InvoiceTestSuiteWithEmbeddedDB {
 
         Mockito.when(billingApi.getBillingEventsForAccountAndUpdateAccountBCD(Mockito.<UUID>any(), Mockito.<DryRunArguments>any(), Mockito.<InternalCallContext>any())).thenReturn(events);
         final InvoiceDispatcher dispatcher = new InvoiceDispatcher(generator, accountApi, billingApi, subscriptionApi, invoiceDao,
-                                                                   internalCallContextFactory, invoicePluginDispatcher, locker, busService.getBus(),
+                                                                   internalCallContextFactory, invoicePluginDispatcher, locker, bus,
                                                                    notificationQueueService, invoiceConfig, clock, invoiceOptimizer, parkedAccountsManager);
         final Invoice invoice = dispatcher.processAccountFromNotificationOrBusEvent(account.getId(), new LocalDate("2012-07-30"), null, false, context);
         Assert.assertNotNull(invoice);

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceHelper.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceHelper.java
@@ -84,6 +84,7 @@ import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.config.definition.InvoiceConfig;
 import org.killbill.billing.util.currency.KillBillMoney;
 import org.killbill.billing.util.dao.NonEntityDao;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.locker.GlobalLocker;
 import org.killbill.notificationq.api.NotificationQueueService;
@@ -155,7 +156,7 @@ public class TestInvoiceHelper {
     private final InvoicePluginDispatcher invoicePluginDispatcher;
     private final AccountUserApi accountUserApi;
     private final SubscriptionBaseInternalApi subscriptionApi;
-    private final BusService busService;
+    private final BusOptimizer eventBus;
     private final InvoiceDao invoiceDao;
     private final GlobalLocker locker;
     private final Clock clock;
@@ -173,7 +174,7 @@ public class TestInvoiceHelper {
 
     @Inject
     public TestInvoiceHelper(final InvoiceGenerator generator, final IDBI dbi,
-                             final BillingInternalApi billingApi, final AccountInternalApi accountApi, final ImmutableAccountInternalApi immutableAccountApi, final InvoicePluginDispatcher invoicePluginDispatcher, final AccountUserApi accountUserApi, final SubscriptionBaseInternalApi subscriptionApi, final BusService busService,
+                             final BillingInternalApi billingApi, final AccountInternalApi accountApi, final ImmutableAccountInternalApi immutableAccountApi, final InvoicePluginDispatcher invoicePluginDispatcher, final AccountUserApi accountUserApi, final SubscriptionBaseInternalApi subscriptionApi, final BusOptimizer eventBus,
                              final InvoiceDao invoiceDao, final GlobalLocker locker, final Clock clock, final NonEntityDao nonEntityDao, final NotificationQueueService notificationQueueService, final MutableInternalCallContext internalCallContext, final InvoiceConfig invoiceConfig,
                              final ParkedAccountsManager parkedAccountsManager, final InvoiceOptimizer invoiceOptimizer, final InternalCallContextFactory internalCallContextFactory) {
         this.generator = generator;
@@ -183,7 +184,7 @@ public class TestInvoiceHelper {
         this.invoicePluginDispatcher = invoicePluginDispatcher;
         this.accountUserApi = accountUserApi;
         this.subscriptionApi = subscriptionApi;
-        this.busService = busService;
+        this.eventBus = eventBus;
         this.invoiceDao = invoiceDao;
         this.locker = locker;
         this.clock = clock;
@@ -239,7 +240,7 @@ public class TestInvoiceHelper {
 
     public Invoice generateInvoice(final UUID accountId, @Nullable final LocalDate targetDate, @Nullable final DryRunArguments dryRunArguments, final InternalCallContext internalCallContext) throws InvoiceApiException {
         final InvoiceDispatcher dispatcher = new InvoiceDispatcher(generator, accountApi, billingApi, subscriptionApi,
-                                                                   invoiceDao, internalCallContextFactory, invoicePluginDispatcher, locker, busService.getBus(),
+                                                                   invoiceDao, internalCallContextFactory, invoicePluginDispatcher, locker, eventBus,
                                                                    notificationQueueService, invoiceConfig, clock, invoiceOptimizer, parkedAccountsManager);
 
         return dispatcher.processAccountFromNotificationOrBusEvent(accountId, targetDate, dryRunArguments, false, internalCallContext);

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
@@ -26,6 +26,7 @@ import org.joda.time.DateTime;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 
@@ -40,8 +41,9 @@ public class TestInvoiceNotificationQListener extends InvoiceListener {
                                             final InternalCallContextFactory internalCallContextFactory,
                                             final InvoiceDispatcher dispatcher,
                                             final InvoiceInternalApi invoiceApi,
+                                            final BusOptimizer busOptimizer,
                                             final NotificationQueueService notificationQueueService) {
-        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, clock);
+        super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, busOptimizer, clock);
     }
 
     @Override

--- a/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/TestInvoiceNotificationQListener.java
@@ -26,7 +26,7 @@ import org.joda.time.DateTime;
 import org.killbill.billing.account.api.AccountInternalApi;
 import org.killbill.billing.invoice.api.InvoiceInternalApi;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
-import org.killbill.billing.util.optimizer.BusOptimizer;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 
@@ -41,7 +41,7 @@ public class TestInvoiceNotificationQListener extends InvoiceListener {
                                             final InternalCallContextFactory internalCallContextFactory,
                                             final InvoiceDispatcher dispatcher,
                                             final InvoiceInternalApi invoiceApi,
-                                            final BusOptimizer busOptimizer,
+                                            final BusDispatcherOptimizer busOptimizer,
                                             final NotificationQueueService notificationQueueService) {
         super(accountApi, internalCallContextFactory, dispatcher, invoiceApi, notificationQueueService, busOptimizer, clock);
     }

--- a/invoice/src/test/java/org/killbill/billing/invoice/glue/TestInvoiceModule.java
+++ b/invoice/src/test/java/org/killbill/billing/invoice/glue/TestInvoiceModule.java
@@ -34,6 +34,7 @@ import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
 import org.killbill.billing.util.glue.CustomFieldModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.mockito.Mockito;
 
 import com.google.common.base.MoreObjects;
@@ -68,6 +69,7 @@ public class TestInvoiceModule extends DefaultInvoiceModule {
         install(new CatalogModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new TemplateModule(configSource));
         install(new MockTenantModule(configSource));
 

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AdminResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AdminResource.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Iterator;
-import java.util.List;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -49,7 +48,6 @@ import org.killbill.billing.ErrorCode;
 import org.killbill.billing.ObjectType;
 import org.killbill.billing.account.api.AccountUserApi;
 import org.killbill.billing.account.api.ImmutableAccountData;
-import org.killbill.billing.catalog.api.StaticCatalog;
 import org.killbill.billing.catalog.api.VersionedCatalog;
 import org.killbill.billing.invoice.api.InvoiceApiException;
 import org.killbill.billing.invoice.api.InvoiceUserApi;
@@ -79,11 +77,11 @@ import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.config.tenant.PerTenantConfig;
 import org.killbill.billing.util.entity.Pagination;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.tag.Tag;
 import org.killbill.billing.util.tag.dao.SystemTags;
 import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.BusEventWithMetadata;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationEventWithMetadata;
@@ -108,7 +106,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
 
 @Singleton
 @Path(JaxrsResource.ADMIN_PATH)
-@Api(value = JaxrsResource.ADMIN_PATH, description = "Admin operations (will require special privileges)", tags="Admin")
+@Api(value = JaxrsResource.ADMIN_PATH, description = "Admin operations (will require special privileges)", tags = "Admin")
 public class AdminResource extends JaxRsResourceBase {
 
     private static final String OK = "OK";
@@ -118,7 +116,7 @@ public class AdminResource extends JaxRsResourceBase {
     private final TenantUserApi tenantApi;
     private final CacheControllerDispatcher cacheControllerDispatcher;
     private final RecordIdApi recordIdApi;
-    private final PersistentBus persistentBus;
+    private final BusOptimizer persistentBus;
     private final NotificationQueueService notificationQueueService;
     private final KillbillHealthcheck killbillHealthcheck;
 
@@ -135,7 +133,7 @@ public class AdminResource extends JaxRsResourceBase {
                          final CacheControllerDispatcher cacheControllerDispatcher,
                          final TenantUserApi tenantApi,
                          final RecordIdApi recordIdApi,
-                         final PersistentBus persistentBus,
+                         final BusOptimizer persistentBus,
                          final NotificationQueueService notificationQueueService,
                          final KillbillHealthcheck killbillHealthcheck,
                          final Clock clock,

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AdminResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/AdminResource.java
@@ -82,6 +82,7 @@ import org.killbill.billing.util.tag.Tag;
 import org.killbill.billing.util.tag.dao.SystemTags;
 import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.BusEventWithMetadata;
+import org.killbill.bus.api.PersistentBus;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
 import org.killbill.notificationq.api.NotificationEventWithMetadata;
@@ -116,7 +117,7 @@ public class AdminResource extends JaxRsResourceBase {
     private final TenantUserApi tenantApi;
     private final CacheControllerDispatcher cacheControllerDispatcher;
     private final RecordIdApi recordIdApi;
-    private final BusOptimizer persistentBus;
+    private final PersistentBus persistentBus;
     private final NotificationQueueService notificationQueueService;
     private final KillbillHealthcheck killbillHealthcheck;
 
@@ -133,7 +134,7 @@ public class AdminResource extends JaxRsResourceBase {
                          final CacheControllerDispatcher cacheControllerDispatcher,
                          final TenantUserApi tenantApi,
                          final RecordIdApi recordIdApi,
-                         final BusOptimizer persistentBus,
+                         final PersistentBus persistentBus,
                          final NotificationQueueService notificationQueueService,
                          final KillbillHealthcheck killbillHealthcheck,
                          final Clock clock,

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/TestResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/TestResource.java
@@ -54,6 +54,7 @@ import org.killbill.billing.util.callcontext.TenantContext;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.BusEventWithMetadata;
+import org.killbill.bus.api.PersistentBus;
 import org.killbill.clock.Clock;
 import org.killbill.clock.ClockMock;
 import org.killbill.notificationq.api.NotificationEvent;
@@ -90,7 +91,7 @@ public class TestResource extends JaxRsResourceBase {
     private static final Logger log = LoggerFactory.getLogger(TestResource.class);
     private static final int MILLIS_IN_SEC = 1000;
 
-    private final BusOptimizer persistentBus;
+    private final PersistentBus persistentBus;
     private final NotificationQueueService notificationQueueService;
     private final RecordIdApi recordIdApi;
     private final TenantUserApi tenantApi;
@@ -100,7 +101,7 @@ public class TestResource extends JaxRsResourceBase {
     @Inject
     public TestResource(final JaxrsUriBuilder uriBuilder, final TagUserApi tagUserApi, final CustomFieldUserApi customFieldUserApi,
                         final AuditUserApi auditUserApi, final AccountUserApi accountUserApi, final RecordIdApi recordIdApi,
-                        final BusOptimizer persistentBus, final NotificationQueueService notificationQueueService, final PaymentApi paymentApi,
+                        final PersistentBus persistentBus, final NotificationQueueService notificationQueueService, final PaymentApi paymentApi,
                         final InvoicePaymentApi invoicePaymentApi, final TenantUserApi tenantApi, final CatalogUserApi catalogUserApi,
                         final Clock clock, final CacheControllerDispatcher cacheControllerDispatcher, final Context context) {
         super(uriBuilder, tagUserApi, customFieldUserApi, auditUserApi, accountUserApi, paymentApi, invoicePaymentApi, null, clock, context);

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/TestResource.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/resources/TestResource.java
@@ -51,9 +51,9 @@ import org.killbill.billing.util.api.RecordIdApi;
 import org.killbill.billing.util.api.TagUserApi;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.TenantContext;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.BusEventWithMetadata;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.clock.Clock;
 import org.killbill.clock.ClockMock;
 import org.killbill.notificationq.api.NotificationEvent;
@@ -90,7 +90,7 @@ public class TestResource extends JaxRsResourceBase {
     private static final Logger log = LoggerFactory.getLogger(TestResource.class);
     private static final int MILLIS_IN_SEC = 1000;
 
-    private final PersistentBus persistentBus;
+    private final BusOptimizer persistentBus;
     private final NotificationQueueService notificationQueueService;
     private final RecordIdApi recordIdApi;
     private final TenantUserApi tenantApi;
@@ -100,7 +100,7 @@ public class TestResource extends JaxRsResourceBase {
     @Inject
     public TestResource(final JaxrsUriBuilder uriBuilder, final TagUserApi tagUserApi, final CustomFieldUserApi customFieldUserApi,
                         final AuditUserApi auditUserApi, final AccountUserApi accountUserApi, final RecordIdApi recordIdApi,
-                        final PersistentBus persistentBus, final NotificationQueueService notificationQueueService, final PaymentApi paymentApi,
+                        final BusOptimizer persistentBus, final NotificationQueueService notificationQueueService, final PaymentApi paymentApi,
                         final InvoicePaymentApi invoicePaymentApi, final TenantUserApi tenantApi, final CatalogUserApi catalogUserApi,
                         final Clock clock, final CacheControllerDispatcher cacheControllerDispatcher, final Context context) {
         super(uriBuilder, tagUserApi, customFieldUserApi, auditUserApi, accountUserApi, paymentApi, invoicePaymentApi, null, clock, context);

--- a/jaxrs/src/main/java/org/killbill/billing/jaxrs/util/KillbillEventHandler.java
+++ b/jaxrs/src/main/java/org/killbill/billing/jaxrs/util/KillbillEventHandler.java
@@ -59,6 +59,7 @@ public class KillbillEventHandler {
     @AllowConcurrentEvents
     @Subscribe
     public void handleSubscriptionEvents(final BusInternalEvent event) {
+        // No BusDispatcherOptimizer logic on purpose
         final List<CompletionUserRequestNotifier> runningWaiters = new ArrayList<CompletionUserRequestNotifier>();
         synchronized (activeWaiters) {
             runningWaiters.addAll(activeWaiters);

--- a/jaxrs/src/test/java/org/killbill/billing/jaxrs/glue/TestJaxrsModuleNoDB.java
+++ b/jaxrs/src/test/java/org/killbill/billing/jaxrs/glue/TestJaxrsModuleNoDB.java
@@ -26,6 +26,7 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.tenant.api.TenantInternalApi;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.clock.ClockMock;
 import org.mockito.Mockito;
 
@@ -47,6 +48,7 @@ public class TestJaxrsModuleNoDB extends TestJaxrsModule {
         install(new MockAccountModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         bind(TenantInternalApi.class).toInstance(Mockito.mock(TenantInternalApi.class));
         bind(SecurityManager.class).toInstance(Mockito.mock(SecurityManager.class));
     }

--- a/junction/src/test/java/org/killbill/billing/junction/glue/TestJunctionModule.java
+++ b/junction/src/test/java/org/killbill/billing/junction/glue/TestJunctionModule.java
@@ -30,6 +30,7 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.KillBillShiroAopModule;
 import org.killbill.billing.util.glue.KillBillShiroModule;
 import org.killbill.billing.util.glue.SecurityModule;
@@ -46,6 +47,7 @@ public class TestJunctionModule extends DefaultJunctionModule {
 
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new MockTenantModule(configSource));
         // Needed because Entitlement depends on Security

--- a/overdue/src/main/java/org/killbill/billing/overdue/applicator/OverdueStateApplicator.java
+++ b/overdue/src/main/java/org/killbill/billing/overdue/applicator/OverdueStateApplicator.java
@@ -60,9 +60,9 @@ import org.killbill.billing.tag.TagInternalApi;
 import org.killbill.billing.util.api.TagApiException;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.killbill.billing.util.tag.Tag;
-import org.killbill.bus.api.PersistentBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +77,7 @@ public class OverdueStateApplicator {
 
     private final BlockingInternalApi blockingApi;
     private final OverduePoster checkPoster;
-    private final PersistentBus bus;
+    private final BusOptimizer bus;
     private final AccountInternalApi accountApi;
     private final EntitlementApi entitlementApi;
     private final EntitlementInternalApi entitlementInternalApi;
@@ -90,7 +90,7 @@ public class OverdueStateApplicator {
                                   final EntitlementApi entitlementApi,
                                   final EntitlementInternalApi entitlementInternalApi,
                                   @Named(DefaultOverdueModule.OVERDUE_NOTIFIER_CHECK_NAMED) final OverduePoster checkPoster,
-                                  final PersistentBus bus,
+                                  final BusOptimizer bus,
                                   final TagInternalApi tagApi,
                                   final InternalCallContextFactory internalCallContextFactory) {
 

--- a/overdue/src/test/java/org/killbill/billing/overdue/glue/TestOverdueModule.java
+++ b/overdue/src/test/java/org/killbill/billing/overdue/glue/TestOverdueModule.java
@@ -47,6 +47,7 @@ import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
 import org.killbill.billing.util.glue.CustomFieldModule;
+import org.killbill.billing.util.glue.EventModule;
 
 import com.google.inject.name.Names;
 
@@ -63,6 +64,7 @@ public class TestOverdueModule extends DefaultOverdueModule {
         install(new AuditModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new CustomFieldModule(configSource));
         install(new MockAccountModule(configSource));

--- a/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
+++ b/payment/src/main/java/org/killbill/billing/payment/config/MultiTenantPaymentConfig.java
@@ -23,11 +23,11 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.killbill.billing.callcontext.InternalTenantContext;
-import org.killbill.billing.payment.glue.PaymentModule;
 import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.killbill.billing.util.config.definition.PaymentConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;
 import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.Param;
 import org.skife.config.TimeSpan;
 
@@ -36,7 +36,7 @@ public class MultiTenantPaymentConfig extends MultiTenantConfigBase implements P
     private final PaymentConfig staticConfig;
 
     @Inject
-    public MultiTenantPaymentConfig(@Named(PaymentModule.STATIC_CONFIG) final PaymentConfig staticConfig, final CacheConfig cacheConfig) {
+    public MultiTenantPaymentConfig(@Named(KillBillModule.STATIC_CONFIG) final PaymentConfig staticConfig, final CacheConfig cacheConfig) {
         super(cacheConfig);
         this.staticConfig = staticConfig;
     }

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/PaymentAutomatonDAOHelper.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/PaymentAutomatonDAOHelper.java
@@ -38,6 +38,7 @@ import org.killbill.billing.payment.dao.PaymentModelDao;
 import org.killbill.billing.payment.dao.PaymentTransactionModelDao;
 import org.killbill.billing.payment.plugin.api.PaymentPluginApi;
 import org.killbill.billing.payment.plugin.api.PaymentTransactionInfoPlugin;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +57,7 @@ public class PaymentAutomatonDAOHelper {
     protected final PaymentDao paymentDao;
 
     private final PaymentPluginServiceRegistration paymentPluginServiceRegistration;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
 
     // Cached
     private String pluginName = null;
@@ -74,7 +75,7 @@ public class PaymentAutomatonDAOHelper {
                                      final DateTime utcNow, final PaymentDao paymentDao,
                                      final PaymentPluginServiceRegistration paymentPluginServiceRegistration,
                                      final InternalCallContext internalCallContext,
-                                     final PersistentBus eventBus,
+                                     final BusOptimizer eventBus,
                                      final PaymentStateMachineHelper paymentSMHelper) {
         this.paymentStateContext = paymentStateContext;
         this.utcNow = utcNow;

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/PaymentAutomatonRunner.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/PaymentAutomatonRunner.java
@@ -73,7 +73,7 @@ import org.killbill.billing.payment.dao.PaymentTransactionModelDao;
 import org.killbill.billing.payment.dispatcher.PluginDispatcher;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.config.definition.PaymentConfig;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.locker.GlobalLocker;
 
@@ -88,7 +88,7 @@ public class PaymentAutomatonRunner {
     protected final PaymentPluginServiceRegistration paymentPluginServiceRegistration;
     protected final Clock clock;
 
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final PaymentConfig paymentConfig;
 
     @Inject
@@ -98,7 +98,7 @@ public class PaymentAutomatonRunner {
                                   final PaymentPluginServiceRegistration paymentPluginServiceRegistration,
                                   final Clock clock,
                                   final PaymentExecutors executors,
-                                  final PersistentBus eventBus,
+                                  final BusOptimizer eventBus,
                                   final PaymentStateMachineHelper paymentSMHelper) {
         this.paymentSMHelper = paymentSMHelper;
         this.paymentDao = paymentDao;

--- a/payment/src/main/java/org/killbill/billing/payment/core/sm/PluginControlPaymentAutomatonRunner.java
+++ b/payment/src/main/java/org/killbill/billing/payment/core/sm/PluginControlPaymentAutomatonRunner.java
@@ -66,7 +66,7 @@ import org.killbill.billing.payment.dao.PaymentDao;
 import org.killbill.billing.payment.retry.BaseRetryService.RetryServiceScheduler;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.config.definition.PaymentConfig;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.locker.GlobalLocker;
 
@@ -101,7 +101,7 @@ public class PluginControlPaymentAutomatonRunner extends PaymentAutomatonRunner 
     public PluginControlPaymentAutomatonRunner(final PaymentDao paymentDao, final GlobalLocker locker, final PaymentPluginServiceRegistration paymentPluginServiceRegistration,
                                                final OSGIServiceRegistration<PaymentControlPluginApi> paymentControlPluginRegistry, final Clock clock, final PaymentProcessor paymentProcessor, @Named(RETRYABLE_NAMED) final RetryServiceScheduler retryServiceScheduler,
                                                final PaymentConfig paymentConfig, final PaymentExecutors executors, final PaymentStateMachineHelper paymentSMHelper, final PaymentControlStateMachineHelper paymentControlStateMachineHelper,
-                                               final ControlPluginRunner controlPluginRunner, final PersistentBus eventBus, final PaymentRefresher paymentRefresher) {
+                                               final ControlPluginRunner controlPluginRunner, final BusOptimizer eventBus, final PaymentRefresher paymentRefresher) {
         super(paymentConfig, paymentDao, locker, paymentPluginServiceRegistration, clock, executors, eventBus, paymentSMHelper);
         this.paymentProcessor = paymentProcessor;
         this.paymentControlPluginRegistry = paymentControlPluginRegistry;

--- a/payment/src/main/java/org/killbill/billing/payment/dao/DefaultPaymentDao.java
+++ b/payment/src/main/java/org/killbill/billing/payment/dao/DefaultPaymentDao.java
@@ -64,7 +64,7 @@ import org.killbill.billing.util.entity.dao.EntityDaoBase;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
 import org.skife.jdbi.v2.IDBI;
@@ -85,13 +85,13 @@ public class DefaultPaymentDao extends EntityDaoBase<PaymentModelDao, Payment, P
     private static final Logger log = LoggerFactory.getLogger(DefaultPaymentDao.class);
 
     private final DefaultPaginationSqlDaoHelper paginationHelper;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final Clock clock;
     private final AuditDao auditDao;
 
     @Inject
     public DefaultPaymentDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final CacheControllerDispatcher cacheControllerDispatcher,
-                             final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory, final PersistentBus eventBus, final AuditDao auditDao) {
+                             final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory, final BusOptimizer eventBus, final AuditDao auditDao) {
         super(nonEntityDao, cacheControllerDispatcher, new EntitySqlDaoTransactionalJdbiWrapper(dbi, roDbi, clock, cacheControllerDispatcher, nonEntityDao, internalCallContextFactory), PaymentSqlDao.class);
         this.paginationHelper = new DefaultPaginationSqlDaoHelper(transactionalSqlDao);
         this.eventBus = eventBus;

--- a/payment/src/main/java/org/killbill/billing/payment/glue/DefaultPaymentService.java
+++ b/payment/src/main/java/org/killbill/billing/payment/glue/DefaultPaymentService.java
@@ -29,6 +29,7 @@ import org.killbill.billing.payment.invoice.PaymentTagHandler;
 import org.killbill.billing.payment.retry.DefaultRetryService;
 import org.killbill.billing.platform.api.LifecycleHandlerType;
 import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus;
 import org.killbill.notificationq.api.NotificationQueueService.NoSuchNotificationQueue;
 import org.killbill.notificationq.api.NotificationQueueService.NotificationQueueAlreadyExists;
@@ -43,7 +44,7 @@ public class DefaultPaymentService implements PaymentService {
 
     private final PaymentBusEventHandler paymentBusEventHandler;
     private final PaymentTagHandler tagHandler;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final PaymentApi api;
     private final DefaultRetryService retryService;
     private final Janitor janitor;
@@ -55,7 +56,7 @@ public class DefaultPaymentService implements PaymentService {
                                  final PaymentTagHandler tagHandler,
                                  final PaymentApi api,
                                  final DefaultRetryService retryService,
-                                 final PersistentBus eventBus,
+                                 final BusOptimizer eventBus,
                                  final Janitor janitor,
                                  final PaymentExecutors paymentExecutors,
                                  final StateMachineConfigCache stateMachineConfigCache) {

--- a/payment/src/main/java/org/killbill/billing/payment/glue/PaymentModule.java
+++ b/payment/src/main/java/org/killbill/billing/payment/glue/PaymentModule.java
@@ -77,8 +77,6 @@ import com.google.inject.name.Names;
 
 public class PaymentModule extends KillBillModule {
 
-    public static final String STATIC_CONFIG = "StaticConfig";
-
     public static final String RETRYABLE_NAMED = "Retryable";
 
     public static final String STATE_MACHINE_RETRY = "RetryStateMachine";
@@ -146,7 +144,7 @@ public class PaymentModule extends KillBillModule {
     protected void configure() {
         final ConfigurationObjectFactory factory = new ConfigurationObjectFactory(skifeConfigSource);
         final PaymentConfig paymentConfig = factory.build(PaymentConfig.class);
-        bind(PaymentConfig.class).annotatedWith(Names.named(STATIC_CONFIG)).toInstance(paymentConfig);
+        bind(PaymentConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(paymentConfig);
         bind(PaymentConfig.class).to(MultiTenantPaymentConfig.class).asEagerSingleton();
 
         bind(new TypeLiteral<OSGIServiceRegistration<PaymentPluginApi>>() {}).toProvider(DefaultPaymentProviderPluginRegistryProvider.class).asEagerSingleton();

--- a/payment/src/test/java/org/killbill/billing/payment/PaymentTestSuiteNoDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/PaymentTestSuiteNoDB.java
@@ -54,7 +54,7 @@ import org.killbill.billing.tenant.api.TenantInternalApi;
 import org.killbill.billing.tenant.api.TenantInternalApi.CacheInvalidationCallback;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.config.definition.PaymentConfig;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.commons.profiling.Profiling;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -80,7 +80,7 @@ public abstract class PaymentTestSuiteNoDB extends GuicyKillbillTestSuiteNoDB {
     @Inject
     protected OSGIServiceRegistration<PaymentPluginApi> registry;
     @Inject
-    protected PersistentBus eventBus;
+    protected BusOptimizer eventBus;
     @Inject
     protected PaymentApi paymentApi;
     @Inject

--- a/payment/src/test/java/org/killbill/billing/payment/PaymentTestSuiteWithEmbeddedDB.java
+++ b/payment/src/test/java/org/killbill/billing/payment/PaymentTestSuiteWithEmbeddedDB.java
@@ -52,7 +52,7 @@ import org.killbill.billing.payment.retry.DefaultRetryService;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.config.definition.PaymentConfig;
 import org.killbill.billing.util.dao.NonEntityDao;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.commons.locker.GlobalLocker;
 import org.killbill.commons.profiling.Profiling;
 import org.testng.annotations.AfterMethod;
@@ -88,7 +88,7 @@ public abstract class PaymentTestSuiteWithEmbeddedDB extends GuicyKillbillTestSu
     @Inject
     protected OSGIServiceRegistration<PaymentControlPluginApi> controlPluginRegistry;
     @Inject
-    protected PersistentBus eventBus;
+    protected BusOptimizer eventBus;
     @Inject
     protected PaymentApi paymentApi;
     @Inject

--- a/payment/src/test/java/org/killbill/billing/payment/core/sm/MockRetryablePaymentAutomatonRunner.java
+++ b/payment/src/test/java/org/killbill/billing/payment/core/sm/MockRetryablePaymentAutomatonRunner.java
@@ -48,7 +48,7 @@ import org.killbill.billing.payment.retry.BaseRetryService.RetryServiceScheduler
 import org.killbill.billing.tag.TagInternalApi;
 import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.config.definition.PaymentConfig;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.commons.locker.GlobalLocker;
 
@@ -62,7 +62,7 @@ public class MockRetryablePaymentAutomatonRunner extends PluginControlPaymentAut
     @Inject
     public MockRetryablePaymentAutomatonRunner(final PaymentDao paymentDao, final GlobalLocker locker, final PaymentPluginServiceRegistration paymentPluginServiceRegistration, final OSGIServiceRegistration<PaymentControlPluginApi> retryPluginRegistry, final Clock clock, final TagInternalApi tagApi, final PaymentProcessor paymentProcessor,
                                                @Named(RETRYABLE_NAMED) final RetryServiceScheduler retryServiceScheduler, final PaymentConfig paymentConfig, final PaymentExecutors executors,
-                                               final PaymentStateMachineHelper paymentSMHelper, final PaymentControlStateMachineHelper retrySMHelper, final ControlPluginRunner controlPluginRunner, final PersistentBus eventBus, final PaymentRefresher paymentRefresher) {
+                                               final PaymentStateMachineHelper paymentSMHelper, final PaymentControlStateMachineHelper retrySMHelper, final ControlPluginRunner controlPluginRunner, final BusOptimizer eventBus, final PaymentRefresher paymentRefresher) {
         super(paymentDao, locker, paymentPluginServiceRegistration, retryPluginRegistry, clock, paymentProcessor, retryServiceScheduler, paymentConfig, executors, paymentSMHelper, retrySMHelper, controlPluginRunner, eventBus, paymentRefresher);
     }
 

--- a/payment/src/test/java/org/killbill/billing/payment/glue/TestPaymentModule.java
+++ b/payment/src/test/java/org/killbill/billing/payment/glue/TestPaymentModule.java
@@ -35,6 +35,7 @@ import org.killbill.billing.util.config.definition.PaymentConfig;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.tag.Tag;
 import org.killbill.clock.Clock;
 import org.mockito.Mockito;
@@ -74,6 +75,7 @@ public class TestPaymentModule extends PaymentModule {
         install(new MockTenantModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
 
         installExternalApis();

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/DefaultServerService.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/DefaultServerService.java
@@ -37,6 +37,7 @@ public class DefaultServerService implements ServerService {
 
     private static final Logger log = LoggerFactory.getLogger(DefaultServerService.class);
 
+    // External bus: Do not use BusOptimizer
     private final PersistentBus bus;
     private final PushNotificationListener pushNotificationListener;
     private final PushNotificationRetryService pushNotificationRetryService;

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/config/MultiTenantNotificationConfig.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/config/MultiTenantNotificationConfig.java
@@ -23,11 +23,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.killbill.billing.callcontext.InternalTenantContext;
-import org.killbill.billing.payment.glue.PaymentModule;
 import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.killbill.billing.util.config.definition.NotificationConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;
 import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.glue.KillBillModule;
 import org.skife.config.Param;
 import org.skife.config.TimeSpan;
 
@@ -40,7 +40,7 @@ public class MultiTenantNotificationConfig extends MultiTenantConfigBase impleme
     private final NotificationConfig staticConfig;
 
     @Inject
-    public MultiTenantNotificationConfig(@Named(PaymentModule.STATIC_CONFIG) final NotificationConfig staticConfig, final CacheConfig cacheConfig) {
+    public MultiTenantNotificationConfig(@Named(KillBillModule.STATIC_CONFIG) final NotificationConfig staticConfig, final CacheConfig cacheConfig) {
         super(cacheConfig);
         this.staticConfig = staticConfig;
     }

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillShiroWebModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillShiroWebModule.java
@@ -64,8 +64,9 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.AnnotatedBindingBuilder;
-import com.google.inject.matcher.AbstractMatcher;
-import com.google.inject.matcher.Matchers;
+import com.google.inject.name.Names;
+
+import static org.killbill.billing.util.glue.KillBillShiroModule.SHIRO_CACHE_MANAGER;
 
 // For Kill Bill server only.
 // See org.killbill.billing.util.glue.KillBillShiroModule for Kill Bill library.
@@ -91,9 +92,9 @@ public class KillBillShiroWebModule extends ShiroWebModuleWith435 {
 
         // Magic provider to configure the cache manager
         if (redisCacheConfig.isRedisCachingEnabled()) {
-            bind(CacheManager.class).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
         } else {
-            bind(CacheManager.class).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
         }
 
         final SecurityConfig securityConfig = new ConfigurationObjectFactory(configSource).build(SecurityConfig.class);

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillShiroWebModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillBillShiroWebModule.java
@@ -64,9 +64,6 @@ import com.google.inject.Key;
 import com.google.inject.Provider;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.AnnotatedBindingBuilder;
-import com.google.inject.name.Names;
-
-import static org.killbill.billing.util.glue.KillBillShiroModule.SHIRO_CACHE_MANAGER;
 
 // For Kill Bill server only.
 // See org.killbill.billing.util.glue.KillBillShiroModule for Kill Bill library.
@@ -92,9 +89,9 @@ public class KillBillShiroWebModule extends ShiroWebModuleWith435 {
 
         // Magic provider to configure the cache manager
         if (redisCacheConfig.isRedisCachingEnabled()) {
-            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
         } else {
-            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
         }
 
         final SecurityConfig securityConfig = new ConfigurationObjectFactory(configSource).build(SecurityConfig.class);

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillJdbcTenantRealmProvider.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillJdbcTenantRealmProvider.java
@@ -28,7 +28,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import static org.killbill.billing.platform.glue.KillBillPlatformModuleBase.SHIRO_DATA_SOURCE_ID;
-import static org.killbill.billing.util.glue.KillBillShiroModule.SHIRO_CACHE_MANAGER;
 
 public class KillbillJdbcTenantRealmProvider implements Provider<KillbillJdbcTenantRealm> {
 
@@ -37,7 +36,7 @@ public class KillbillJdbcTenantRealmProvider implements Provider<KillbillJdbcTen
     private final DataSource dataSource;
 
     @Inject
-    public KillbillJdbcTenantRealmProvider(final SecurityConfig securityConfig, @Named(SHIRO_CACHE_MANAGER) final CacheManager cacheManager, @Named(SHIRO_DATA_SOURCE_ID) final DataSource dataSource) {
+    public KillbillJdbcTenantRealmProvider(final SecurityConfig securityConfig, final CacheManager cacheManager, @Named(SHIRO_DATA_SOURCE_ID) final DataSource dataSource) {
         this.securityConfig = securityConfig;
         this.cacheManager = cacheManager;
         this.dataSource = dataSource;

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillJdbcTenantRealmProvider.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillJdbcTenantRealmProvider.java
@@ -28,6 +28,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import static org.killbill.billing.platform.glue.KillBillPlatformModuleBase.SHIRO_DATA_SOURCE_ID;
+import static org.killbill.billing.util.glue.KillBillShiroModule.SHIRO_CACHE_MANAGER;
 
 public class KillbillJdbcTenantRealmProvider implements Provider<KillbillJdbcTenantRealm> {
 
@@ -36,7 +37,7 @@ public class KillbillJdbcTenantRealmProvider implements Provider<KillbillJdbcTen
     private final DataSource dataSource;
 
     @Inject
-    public KillbillJdbcTenantRealmProvider(final SecurityConfig securityConfig, final CacheManager cacheManager, @Named(SHIRO_DATA_SOURCE_ID) final DataSource dataSource) {
+    public KillbillJdbcTenantRealmProvider(final SecurityConfig securityConfig, @Named(SHIRO_CACHE_MANAGER) final CacheManager cacheManager, @Named(SHIRO_DATA_SOURCE_ID) final DataSource dataSource) {
         this.securityConfig = securityConfig;
         this.cacheManager = cacheManager;
         this.dataSource = dataSource;

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -64,6 +64,8 @@ import org.killbill.billing.util.glue.NonEntityDaoModule;
 import org.killbill.billing.util.glue.RecordIdModule;
 import org.killbill.billing.util.glue.SecurityModule;
 import org.killbill.billing.util.glue.TagStoreModule;
+import org.killbill.billing.util.optimizer.BusOptimizer;
+import org.killbill.billing.util.optimizer.BusOptimizerNoop;
 import org.killbill.clock.Clock;
 import org.killbill.clock.ClockMock;
 import org.killbill.commons.embeddeddb.EmbeddedDB;
@@ -95,6 +97,12 @@ public class KillbillServerModule extends KillbillPlatformModule {
         configurePushNotification();
 
         bind(new TypeLiteral<OSGIServiceRegistration<Healthcheck>>() {}).to(DefaultHealthcheckPluginRegistry.class).asEagerSingleton();
+    }
+
+    @Override
+    protected void configureBuses() {
+        super.configureBuses();
+        this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
     }
 
     @Override

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -45,8 +45,6 @@ import org.killbill.billing.server.notifications.PushNotificationRetryService;
 import org.killbill.billing.subscription.glue.DefaultSubscriptionModule;
 import org.killbill.billing.tenant.glue.DefaultTenantModule;
 import org.killbill.billing.usage.glue.UsageModule;
-import org.killbill.billing.util.config.definition.EventConfig;
-import org.killbill.billing.util.config.definition.MultiTenantEventConfig;
 import org.killbill.billing.util.config.definition.NotificationConfig;
 import org.killbill.billing.util.email.templates.TemplateModule;
 import org.killbill.billing.util.features.KillbillFeatures;

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -46,8 +46,8 @@ import org.killbill.billing.subscription.glue.DefaultSubscriptionModule;
 import org.killbill.billing.tenant.glue.DefaultTenantModule;
 import org.killbill.billing.usage.glue.UsageModule;
 import org.killbill.billing.util.config.definition.EventConfig;
+import org.killbill.billing.util.config.definition.MultiTenantEventConfig;
 import org.killbill.billing.util.config.definition.NotificationConfig;
-import org.killbill.billing.util.config.definition.SecurityConfig;
 import org.killbill.billing.util.email.templates.TemplateModule;
 import org.killbill.billing.util.features.KillbillFeatures;
 import org.killbill.billing.util.glue.AuditModule;
@@ -60,6 +60,7 @@ import org.killbill.billing.util.glue.CustomFieldModule;
 import org.killbill.billing.util.glue.ExportModule;
 import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.IDBISetup;
+import org.killbill.billing.util.glue.KillBillModule;
 import org.killbill.billing.util.glue.KillBillShiroAopModule;
 import org.killbill.billing.util.glue.KillbillApiAopModule;
 import org.killbill.billing.util.glue.NodesModule;
@@ -83,8 +84,6 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 
 public class KillbillServerModule extends KillbillPlatformModule {
-
-    public static final String STATIC_CONFIG = "StaticConfig";
 
     private final KillbillFeatures killbillFeatures;
 
@@ -110,8 +109,8 @@ public class KillbillServerModule extends KillbillPlatformModule {
     protected void configureBuses() {
         super.configureBuses();
         final EventConfig eventConfig = new ConfigurationObjectFactory(skifeConfigSource).build(EventConfig.class);
-        bind(EventConfig.class).toInstance(eventConfig);
-
+        bind(EventConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(eventConfig);
+        bind(EventConfig.class).to(MultiTenantEventConfig.class);
         if (killbillFeatures.isBusOptimizationOn()) {
             this.bind(BusOptimizer.class).to(BusOptimizerOn.class).asEagerSingleton();
         } else {
@@ -207,7 +206,7 @@ public class KillbillServerModule extends KillbillPlatformModule {
     protected void configurePushNotification() {
         final ConfigurationObjectFactory factory = new ConfigurationObjectFactory(skifeConfigSource);
         final NotificationConfig notificationConfig = factory.build(NotificationConfig.class);
-        bind(NotificationConfig.class).annotatedWith(Names.named(STATIC_CONFIG)).toInstance(notificationConfig);
+        bind(NotificationConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(notificationConfig);
         bind(NotificationConfig.class).to(MultiTenantNotificationConfig.class).asEagerSingleton();
         bind(PushNotificationListener.class).asEagerSingleton();
         bind(PushNotificationRetryService.class).asEagerSingleton();

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -55,6 +55,7 @@ import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ClockModule;
 import org.killbill.billing.util.glue.ConfigModule;
 import org.killbill.billing.util.glue.CustomFieldModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.ExportModule;
 import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.IDBISetup;
@@ -167,6 +168,7 @@ public class KillbillServerModule extends KillbillPlatformModule {
         install(new BeatrixModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new CatalogModule(configSource));
         install(new CurrencyModule(configSource));

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -108,9 +108,6 @@ public class KillbillServerModule extends KillbillPlatformModule {
     @Override
     protected void configureBuses() {
         super.configureBuses();
-        final EventConfig eventConfig = new ConfigurationObjectFactory(skifeConfigSource).build(EventConfig.class);
-        bind(EventConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(eventConfig);
-        bind(EventConfig.class).to(MultiTenantEventConfig.class);
         if (killbillFeatures.isBusOptimizationOn()) {
             this.bind(BusOptimizer.class).to(BusOptimizerOn.class).asEagerSingleton();
         } else {

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/modules/KillbillServerModule.java
@@ -68,6 +68,9 @@ import org.killbill.billing.util.glue.NonEntityDaoModule;
 import org.killbill.billing.util.glue.RecordIdModule;
 import org.killbill.billing.util.glue.SecurityModule;
 import org.killbill.billing.util.glue.TagStoreModule;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizerNoop;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizerOn;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.optimizer.BusOptimizerNoop;
 import org.killbill.billing.util.optimizer.BusOptimizerOn;
@@ -110,8 +113,10 @@ public class KillbillServerModule extends KillbillPlatformModule {
         super.configureBuses();
         if (killbillFeatures.isBusOptimizationOn()) {
             this.bind(BusOptimizer.class).to(BusOptimizerOn.class).asEagerSingleton();
+            this.bind(BusDispatcherOptimizer.class).to(BusDispatcherOptimizerOn.class).asEagerSingleton();
         } else {
             this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+            this.bind(BusDispatcherOptimizer.class).to(BusDispatcherOptimizerNoop.class).asEagerSingleton();
         }
     }
 

--- a/profiles/killbill/src/test/java/org/killbill/billing/server/log/TestServerModuleNoDB.java
+++ b/profiles/killbill/src/test/java/org/killbill/billing/server/log/TestServerModuleNoDB.java
@@ -22,8 +22,10 @@ import org.killbill.billing.mock.glue.MockAccountModule;
 import org.killbill.billing.mock.glue.MockNonEntityDaoModule;
 import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
+import org.killbill.billing.util.config.definition.EventConfig;
 import org.killbill.billing.util.glue.KillBillModule;
 import org.killbill.clock.ClockMock;
+import org.skife.config.ConfigurationObjectFactory;
 
 import com.google.inject.util.Providers;
 
@@ -43,5 +45,7 @@ public class TestServerModuleNoDB extends KillBillModule {
         install(new MockNonEntityDaoModule(configSource));
         install(new MockAccountModule(configSource));
         bind(CacheControllerDispatcher.class).toProvider(Providers.<CacheControllerDispatcher>of(null));
+        final EventConfig eventConfig = new ConfigurationObjectFactory(skifeConfigSource).build(EventConfig.class);
+        bind(EventConfig.class).toInstance(eventConfig);
     }
 }

--- a/profiles/killpay/src/main/java/org/killbill/billing/server/modules/KillpayServerModule.java
+++ b/profiles/killpay/src/main/java/org/killbill/billing/server/modules/KillpayServerModule.java
@@ -41,6 +41,7 @@ import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
 import org.killbill.billing.util.glue.CustomFieldModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.ExportModule;
 import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.KillBillShiroAopModule;
@@ -65,6 +66,7 @@ public class KillpayServerModule extends KillbillServerModule {
         install(new BeatrixModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
         install(new CurrencyModule(configSource));
         install(new CustomFieldModule(configSource));

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/core/DefaultSubscriptionBaseService.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/core/DefaultSubscriptionBaseService.java
@@ -45,8 +45,8 @@ import org.killbill.billing.util.callcontext.CallContext;
 import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.BusEvent;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
@@ -69,7 +69,7 @@ public class DefaultSubscriptionBaseService implements EventListener, Subscripti
     private final Clock clock;
     private final SubscriptionDao dao;
     private final PlanAligner planAligner;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final NotificationQueueService notificationQueueService;
     private final InternalCallContextFactory internalCallContextFactory;
     private final SubscriptionBaseApiService apiService;
@@ -81,7 +81,7 @@ public class DefaultSubscriptionBaseService implements EventListener, Subscripti
     public DefaultSubscriptionBaseService(final Clock clock,
                                           final SubscriptionDao dao,
                                           final PlanAligner planAligner,
-                                          final PersistentBus eventBus,
+                                          final BusOptimizer eventBus,
                                           final NotificationQueueService notificationQueueService,
                                           final InternalCallContextFactory internalCallContextFactory,
                                           final SubscriptionBaseApiService apiService,

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -99,8 +99,8 @@ import org.killbill.billing.util.entity.dao.EntitySqlDao;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.BusEvent;
-import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationEvent;
@@ -129,12 +129,12 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
     private final Clock clock;
     private final NotificationQueueService notificationQueueService;
     private final AddonUtils addonUtils;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final AuditDao auditDao;
 
     @Inject
     public DefaultSubscriptionDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final AddonUtils addonUtils,
-                                  final NotificationQueueService notificationQueueService, final PersistentBus eventBus,
+                                  final NotificationQueueService notificationQueueService, final BusOptimizer eventBus,
                                   final CacheControllerDispatcher cacheControllerDispatcher, final NonEntityDao nonEntityDao,
                                   final AuditDao auditDao,
                                   final InternalCallContextFactory internalCallContextFactory) {

--- a/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteWithEmbeddedDB.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/SubscriptionTestSuiteWithEmbeddedDB.java
@@ -47,7 +47,7 @@ import org.killbill.billing.util.api.AuditUserApi;
 import org.killbill.billing.util.audit.dao.AuditDao;
 import org.killbill.billing.util.config.definition.SubscriptionConfig;
 import org.killbill.billing.util.dao.NonEntityDao;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +74,7 @@ public class SubscriptionTestSuiteWithEmbeddedDB extends GuicyKillbillTestSuiteW
     @Inject
     protected SubscriptionBaseTransferApi transferApi;
     @Inject
-    protected PersistentBus bus;
+    protected BusOptimizer bus;
     @Inject
     protected SubscriptionBaseTimelineApi repairApi;
     @Inject

--- a/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/MockSubscriptionDaoSql.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/engine/dao/MockSubscriptionDaoSql.java
@@ -25,7 +25,7 @@ import org.killbill.billing.util.audit.dao.AuditDao;
 import org.killbill.billing.util.cache.CacheControllerDispatcher;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.dao.NonEntityDao;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.clock.Clock;
 import org.killbill.notificationq.api.NotificationQueueService;
 import org.skife.jdbi.v2.IDBI;
@@ -38,7 +38,7 @@ public class MockSubscriptionDaoSql extends DefaultSubscriptionDao {
 
     @Inject
     public MockSubscriptionDaoSql(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final AddonUtils addonUtils, final NotificationQueueService notificationQueueService,
-                                  final PersistentBus eventBus, final CacheControllerDispatcher cacheControllerDispatcher,
+                                  final BusOptimizer eventBus, final CacheControllerDispatcher cacheControllerDispatcher,
                                   final NonEntityDao nonEntityDao, final AuditDao auditDao, final InternalCallContextFactory internalCallContextFactory) {
         super(dbi, roDbi, clock, addonUtils, notificationQueueService, eventBus, cacheControllerDispatcher, nonEntityDao, auditDao, internalCallContextFactory);
     }

--- a/subscription/src/test/java/org/killbill/billing/subscription/glue/TestDefaultSubscriptionModule.java
+++ b/subscription/src/test/java/org/killbill/billing/subscription/glue/TestDefaultSubscriptionModule.java
@@ -28,6 +28,7 @@ import org.killbill.billing.subscription.api.user.TestSubscriptionHelper;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 
 public class TestDefaultSubscriptionModule extends DefaultSubscriptionModule {
 
@@ -42,6 +43,7 @@ public class TestDefaultSubscriptionModule extends DefaultSubscriptionModule {
         install(new CallContextModule(configSource));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new MockTenantModule(configSource));
 
         bind(TestSubscriptionHelper.class).asEagerSingleton();

--- a/tenant/src/main/java/org/killbill/billing/tenant/api/TenantCacheInvalidation.java
+++ b/tenant/src/main/java/org/killbill/billing/tenant/api/TenantCacheInvalidation.java
@@ -70,7 +70,7 @@ public class TenantCacheInvalidation {
     private final Multimap<TenantKey, CacheInvalidationCallback> cache;
     private final TenantBroadcastDao broadcastDao;
     private final TenantConfig tenantConfig;
-    private final BusOptimizer eventBus;
+    private final PersistentBus eventBus;
     private final TenantDao tenantDao;
     private AtomicLong latestRecordIdProcessed;
     private volatile boolean isStopped;
@@ -80,7 +80,7 @@ public class TenantCacheInvalidation {
     @Inject
     public TenantCacheInvalidation(@Named(DefaultTenantModule.NO_CACHING_TENANT) final TenantBroadcastDao broadcastDao,
                                    @Named(DefaultTenantModule.NO_CACHING_TENANT) final TenantDao tenantDao,
-                                   final BusOptimizer eventBus,
+                                   final PersistentBus eventBus,
                                    final TenantConfig tenantConfig) {
         this.cache = HashMultimap.<TenantKey, CacheInvalidationCallback>create();
         this.broadcastDao = broadcastDao;

--- a/tenant/src/main/java/org/killbill/billing/tenant/api/TenantCacheInvalidation.java
+++ b/tenant/src/main/java/org/killbill/billing/tenant/api/TenantCacheInvalidation.java
@@ -38,6 +38,7 @@ import org.killbill.billing.tenant.dao.TenantDao;
 import org.killbill.billing.tenant.dao.TenantKVModelDao;
 import org.killbill.billing.tenant.glue.DefaultTenantModule;
 import org.killbill.billing.util.config.definition.TenantConfig;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.commons.concurrent.Executors;
@@ -69,7 +70,7 @@ public class TenantCacheInvalidation {
     private final Multimap<TenantKey, CacheInvalidationCallback> cache;
     private final TenantBroadcastDao broadcastDao;
     private final TenantConfig tenantConfig;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
     private final TenantDao tenantDao;
     private AtomicLong latestRecordIdProcessed;
     private volatile boolean isStopped;
@@ -79,7 +80,7 @@ public class TenantCacheInvalidation {
     @Inject
     public TenantCacheInvalidation(@Named(DefaultTenantModule.NO_CACHING_TENANT) final TenantBroadcastDao broadcastDao,
                                    @Named(DefaultTenantModule.NO_CACHING_TENANT) final TenantDao tenantDao,
-                                   final PersistentBus eventBus,
+                                   final BusOptimizer eventBus,
                                    final TenantConfig tenantConfig) {
         this.cache = HashMultimap.<TenantKey, CacheInvalidationCallback>create();
         this.broadcastDao = broadcastDao;

--- a/tenant/src/test/java/org/killbill/billing/tenant/glue/TestTenantModule.java
+++ b/tenant/src/test/java/org/killbill/billing/tenant/glue/TestTenantModule.java
@@ -22,6 +22,7 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.CallContextModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 
 public class TestTenantModule extends DefaultTenantModule {
 
@@ -35,6 +36,7 @@ public class TestTenantModule extends DefaultTenantModule {
 
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new CallContextModule(configSource));
     }
 }

--- a/usage/src/test/java/org/killbill/billing/usage/glue/TestUsageModuleWithEmbeddedDB.java
+++ b/usage/src/test/java/org/killbill/billing/usage/glue/TestUsageModuleWithEmbeddedDB.java
@@ -24,6 +24,7 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.util.glue.AuditModule;
 import org.killbill.billing.util.glue.CacheModule;
 import org.killbill.billing.util.glue.ConfigModule;
+import org.killbill.billing.util.glue.EventModule;
 import org.killbill.billing.util.glue.NonEntityDaoModule;
 import org.killbill.clock.ClockMock;
 
@@ -43,6 +44,7 @@ public class TestUsageModuleWithEmbeddedDB extends TestUsageModule {
         install(new GuicyKillbillTestWithEmbeddedDBModule(configSource, clock));
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new NonEntityDaoModule(configSource));
         install(new DefaultAccountModule(configSource));
         install(new AuditModule(configSource));

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>killbill-util</name>
     <properties>
+        <killbill.features.bus.optimization>false</killbill.features.bus.optimization>
         <killbill.features.invoice.optimization>false</killbill.features.invoice.optimization>
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>

--- a/util/src/main/java-templates/org/killbill/billing/util/features/KillbillFeatures.java
+++ b/util/src/main/java-templates/org/killbill/billing/util/features/KillbillFeatures.java
@@ -22,15 +22,24 @@ import com.google.common.base.MoreObjects;
 public final class KillbillFeatures {
 
     public static final String PROP_FEATURE_INVOICE_OPTIMIZATION = "killbill.features.invoice.optimization";
+    public static final String PROP_FEATURE_BUS_OPTIMIZATION = "killbill.features.bus.optimization";
 
     private static final String FEATURE_INVOICE_OPTIMIZATION = "${killbill.features.invoice.optimization}";
+    private static final String FEATURE_BUS_OPTIMIZATION = "${killbill.features.bus.optimization}";
+
     private final boolean isInvoiceOptimizationOn;
+    private final boolean isBusOptimizationOn;
 
     public KillbillFeatures() {
         this.isInvoiceOptimizationOn = Boolean.valueOf(MoreObjects.<String>firstNonNull(FEATURE_INVOICE_OPTIMIZATION, "false"));
+        this.isBusOptimizationOn = Boolean.valueOf(MoreObjects.<String>firstNonNull(FEATURE_BUS_OPTIMIZATION, "false"));
     }
 
     public boolean isInvoiceOptimizationOn() {
         return isInvoiceOptimizationOn;
+    }
+
+    public boolean isBusOptimizationOn() {
+        return isBusOptimizationOn;
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastApi.java
+++ b/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastApi.java
@@ -25,6 +25,7 @@ import org.killbill.billing.events.BroadcastInternalEvent;
 import org.killbill.billing.util.broadcast.dao.BroadcastDao;
 import org.killbill.billing.util.broadcast.dao.BroadcastModelDao;
 import org.killbill.billing.util.optimizer.BusOptimizer;
+import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,10 +35,10 @@ public class DefaultBroadcastApi implements BroadcastApi {
     private final Logger logger = LoggerFactory.getLogger(DefaultBroadcastApi.class);
 
     private final BroadcastDao dao;
-    private final BusOptimizer eventBus;
+    private final PersistentBus eventBus;
 
     @Inject
-    public DefaultBroadcastApi(final BroadcastDao dao, final BusOptimizer eventBus) {
+    public DefaultBroadcastApi(final BroadcastDao dao, final PersistentBus eventBus) {
         this.dao = dao;
         this.eventBus = eventBus;
     }

--- a/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastApi.java
+++ b/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastApi.java
@@ -24,7 +24,7 @@ import org.killbill.billing.broadcast.BroadcastApi;
 import org.killbill.billing.events.BroadcastInternalEvent;
 import org.killbill.billing.util.broadcast.dao.BroadcastDao;
 import org.killbill.billing.util.broadcast.dao.BroadcastModelDao;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,10 +34,10 @@ public class DefaultBroadcastApi implements BroadcastApi {
     private final Logger logger = LoggerFactory.getLogger(DefaultBroadcastApi.class);
 
     private final BroadcastDao dao;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
 
     @Inject
-    public DefaultBroadcastApi(final BroadcastDao dao, final PersistentBus eventBus) {
+    public DefaultBroadcastApi(final BroadcastDao dao, final BusOptimizer eventBus) {
         this.dao = dao;
         this.eventBus = eventBus;
     }

--- a/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastService.java
+++ b/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastService.java
@@ -30,7 +30,7 @@ import org.killbill.billing.platform.api.LifecycleHandlerType.LifecycleLevel;
 import org.killbill.billing.util.broadcast.dao.BroadcastDao;
 import org.killbill.billing.util.broadcast.dao.BroadcastModelDao;
 import org.killbill.billing.util.config.definition.BroadcastConfig;
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.commons.concurrent.Executors;
 import org.slf4j.Logger;
@@ -45,14 +45,14 @@ public class DefaultBroadcastService implements BroadcastService {
 
     private final BroadcastConfig broadcastConfig;
     private final BroadcastDao broadcastDao;
-    private final PersistentBus eventBus;
+    private final BusOptimizer eventBus;
 
     private AtomicLong latestRecordIdProcessed;
     private ScheduledExecutorService broadcastExecutor;
     private volatile boolean isStopped;
 
     @Inject
-    public DefaultBroadcastService(final BroadcastDao broadcastDao, final BroadcastConfig broadcastConfig, final PersistentBus eventBus) {
+    public DefaultBroadcastService(final BroadcastDao broadcastDao, final BroadcastConfig broadcastConfig, final BusOptimizer eventBus) {
         this.broadcastDao = broadcastDao;
         this.broadcastConfig = broadcastConfig;
         this.eventBus = eventBus;
@@ -121,9 +121,9 @@ public class DefaultBroadcastService implements BroadcastService {
 
         private final DefaultBroadcastService parent;
         private final BroadcastDao broadcastDao;
-        private final PersistentBus eventBus;
+        private final BusOptimizer eventBus;
 
-        public BroadcastServiceRunnable(final DefaultBroadcastService defaultBroadcastService, final BroadcastDao broadcastDao, final PersistentBus eventBus) {
+        public BroadcastServiceRunnable(final DefaultBroadcastService defaultBroadcastService, final BroadcastDao broadcastDao, final BusOptimizer eventBus) {
             this.parent = defaultBroadcastService;
             this.broadcastDao = broadcastDao;
             this.eventBus = eventBus;

--- a/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastService.java
+++ b/util/src/main/java/org/killbill/billing/util/broadcast/DefaultBroadcastService.java
@@ -31,6 +31,7 @@ import org.killbill.billing.util.broadcast.dao.BroadcastDao;
 import org.killbill.billing.util.broadcast.dao.BroadcastModelDao;
 import org.killbill.billing.util.config.definition.BroadcastConfig;
 import org.killbill.billing.util.optimizer.BusOptimizer;
+import org.killbill.bus.api.PersistentBus;
 import org.killbill.bus.api.PersistentBus.EventBusException;
 import org.killbill.commons.concurrent.Executors;
 import org.slf4j.Logger;
@@ -45,14 +46,14 @@ public class DefaultBroadcastService implements BroadcastService {
 
     private final BroadcastConfig broadcastConfig;
     private final BroadcastDao broadcastDao;
-    private final BusOptimizer eventBus;
+    private final PersistentBus eventBus;
 
     private AtomicLong latestRecordIdProcessed;
     private ScheduledExecutorService broadcastExecutor;
     private volatile boolean isStopped;
 
     @Inject
-    public DefaultBroadcastService(final BroadcastDao broadcastDao, final BroadcastConfig broadcastConfig, final BusOptimizer eventBus) {
+    public DefaultBroadcastService(final BroadcastDao broadcastDao, final BroadcastConfig broadcastConfig, final PersistentBus eventBus) {
         this.broadcastDao = broadcastDao;
         this.broadcastConfig = broadcastConfig;
         this.eventBus = eventBus;
@@ -121,9 +122,9 @@ public class DefaultBroadcastService implements BroadcastService {
 
         private final DefaultBroadcastService parent;
         private final BroadcastDao broadcastDao;
-        private final BusOptimizer eventBus;
+        private final PersistentBus eventBus;
 
-        public BroadcastServiceRunnable(final DefaultBroadcastService defaultBroadcastService, final BroadcastDao broadcastDao, final BusOptimizer eventBus) {
+        public BroadcastServiceRunnable(final DefaultBroadcastService defaultBroadcastService, final BroadcastDao broadcastDao, final PersistentBus eventBus) {
             this.parent = defaultBroadcastService;
             this.broadcastDao = broadcastDao;
             this.eventBus = eventBus;

--- a/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
@@ -33,6 +33,7 @@ public interface EventConfig extends KillbillConfig {
     @Description("List of event types to be skipped (not posted)")
     List<BusInternalEventType> getSkipPostBusEventTypeList();
 
+    // Not fully implemented
     @Config("org.killbill.billing.server.event.post.type.skip")
     @Default("")
     @Description("List of event types to be skipped (not posted)")
@@ -47,5 +48,16 @@ public interface EventConfig extends KillbillConfig {
     @Default("")
     @Description("List of event types to be skipped (not dispatched internally)")
     List<BusInternalEventType> getSkipDispatchBusEventTypeList(@Param("dummy") final InternalTenantContext tenantContext);
+
+
+    @Config("org.killbill.billing.server.event.bulk.subscription.aggregate")
+    @Default("false")
+    @Description("List of event types to be skipped (not dispatched internally)")
+    boolean isAggregateBulkSubscriptionEvents();
+
+    @Config("org.killbill.billing.server.event.bulk.subscription.aggregate")
+    @Default("false")
+    @Description("List of event types to be skipped (not dispatched internally)")
+    boolean isAggregateBulkSubscriptionEvents(@Param("dummy") final InternalTenantContext tenantContext);
 
 }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2014-2016 Groupon, Inc
+ * Copyright 2014-2016 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.config.definition;
+
+import java.util.List;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.events.BusInternalEvent.BusInternalEventType;
+import org.skife.config.Config;
+import org.skife.config.Default;
+import org.skife.config.Description;
+import org.skife.config.Param;
+import org.skife.config.TimeSpan;
+
+public interface EventConfig extends KillbillConfig {
+
+    @Config("org.killbill.billing.server.event.post.type.skip")
+    @Default("")
+    @Description("Delay before which unresolved push notifications should be retried")
+    List<BusInternalEventType> getSkipPostBusEventTypeList();
+
+
+}

--- a/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
@@ -25,14 +25,27 @@ import org.skife.config.Config;
 import org.skife.config.Default;
 import org.skife.config.Description;
 import org.skife.config.Param;
-import org.skife.config.TimeSpan;
 
 public interface EventConfig extends KillbillConfig {
 
     @Config("org.killbill.billing.server.event.post.type.skip")
     @Default("")
-    @Description("Delay before which unresolved push notifications should be retried")
+    @Description("List of event types to be skipped (not posted)")
     List<BusInternalEventType> getSkipPostBusEventTypeList();
 
+    @Config("org.killbill.billing.server.event.post.type.skip")
+    @Default("")
+    @Description("List of event types to be skipped (not posted)")
+    List<BusInternalEventType> getSkipPostBusEventTypeList(@Param("dummy") final InternalTenantContext tenantContext);
+
+    @Config("org.killbill.billing.server.event.dispatch.type.skip")
+    @Default("")
+    @Description("List of event types to be skipped (not dispatched internally)")
+    List<BusInternalEventType> getSkipDispatchBusEventTypeList();
+
+    @Config("org.killbill.billing.server.event.dispatch.type.skip")
+    @Default("")
+    @Description("List of event types to be skipped (not dispatched internally)")
+    List<BusInternalEventType> getSkipDispatchBusEventTypeList(@Param("dummy") final InternalTenantContext tenantContext);
 
 }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/EventConfig.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the

--- a/util/src/main/java/org/killbill/billing/util/config/definition/MultiTenantEventConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/MultiTenantEventConfig.java
@@ -67,6 +67,20 @@ public class MultiTenantEventConfig extends MultiTenantConfigBase implements Eve
     }
 
     @Override
+    public boolean isAggregateBulkSubscriptionEvents() {
+        return staticConfig.isAggregateBulkSubscriptionEvents();
+    }
+
+    @Override
+    public boolean isAggregateBulkSubscriptionEvents(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("isAggregateBulkSubscriptionEvents", tenantContext);
+        if (result != null) {
+            return Boolean.parseBoolean(result);
+        }
+        return isAggregateBulkSubscriptionEvents();
+    }
+
+    @Override
     protected Class<? extends KillbillConfig> getConfigClass() {
         return EventConfig.class;
     }

--- a/util/src/main/java/org/killbill/billing/util/config/definition/MultiTenantEventConfig.java
+++ b/util/src/main/java/org/killbill/billing/util/config/definition/MultiTenantEventConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.config.definition;
+
+import java.util.List;
+
+import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.events.BusInternalEvent.BusInternalEventType;
+import org.killbill.billing.util.config.tenant.CacheConfig;
+import org.killbill.billing.util.config.tenant.MultiTenantConfigBase;
+import org.killbill.billing.util.glue.KillBillModule;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+public class MultiTenantEventConfig extends MultiTenantConfigBase implements EventConfig {
+
+    private final EventConfig staticConfig;
+
+    @Inject
+    public MultiTenantEventConfig(@Named(KillBillModule.STATIC_CONFIG) final EventConfig staticConfig, final CacheConfig cacheConfig) {
+        super(cacheConfig);
+        this.staticConfig = staticConfig;
+    }
+
+    @Override
+    public List<BusInternalEventType> getSkipPostBusEventTypeList() {
+        return staticConfig.getSkipPostBusEventTypeList();
+    }
+
+    @Override
+    public List<BusInternalEventType> getSkipPostBusEventTypeList(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("getSkipPostBusEventTypeList", tenantContext);
+        if (result != null) {
+            return convertToListBusInternalEventType(result, "getSkipPostBusEventTypeList");
+        }
+        return getSkipPostBusEventTypeList();
+    }
+
+    @Override
+    public List<BusInternalEventType> getSkipDispatchBusEventTypeList() {
+        return staticConfig.getSkipDispatchBusEventTypeList();
+    }
+
+    @Override
+    public List<BusInternalEventType> getSkipDispatchBusEventTypeList(final InternalTenantContext tenantContext) {
+        final String result = getStringTenantConfig("getSkipDispatchBusEventTypeList", tenantContext);
+        if (result != null) {
+            return convertToListBusInternalEventType(result, "getSkipDispatchBusEventTypeList");
+        }
+        return getSkipDispatchBusEventTypeList();
+    }
+
+    @Override
+    protected Class<? extends KillbillConfig> getConfigClass() {
+        return EventConfig.class;
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantConfigBase.java
+++ b/util/src/main/java/org/killbill/billing/util/config/tenant/MultiTenantConfigBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.killbill.billing.callcontext.InternalTenantContext;
+import org.killbill.billing.events.BusInternalEvent.BusInternalEventType;
 import org.killbill.billing.util.config.definition.KillbillConfig;
 import org.skife.config.Config;
 import org.skife.config.Separator;
@@ -51,6 +52,14 @@ public abstract class MultiTenantConfigBase {
         }
     };
 
+    private final static Function<String, BusInternalEventType> BUS_EVENT_TYPE_CONVERTER = new Function<String, BusInternalEventType>() {
+        @Override
+        public BusInternalEventType apply(final String input) {
+            return BusInternalEventType.valueOf(input);
+        }
+    };
+
+
     public MultiTenantConfigBase(final CacheConfig cacheConfig) {
         this.cacheConfig = cacheConfig;
     }
@@ -70,6 +79,12 @@ public abstract class MultiTenantConfigBase {
         final Method method = getConfigStaticMethodWithChecking(methodName);
         final Iterable<String> tokens = getTokens(method, value);
         return ImmutableList.copyOf(Iterables.transform(tokens, TIME_SPAN_CONVERTER));
+    }
+
+    protected List<BusInternalEventType> convertToListBusInternalEventType(final String value, final String methodName) {
+        final Method method = getConfigStaticMethodWithChecking(methodName);
+        final Iterable<String> tokens = getTokens(method, value);
+        return ImmutableList.copyOf(Iterables.transform(tokens, BUS_EVENT_TYPE_CONVERTER));
     }
 
     protected List<Integer> convertToListInteger(final String value, final String methodName) {

--- a/util/src/main/java/org/killbill/billing/util/customfield/dao/DefaultCustomFieldDao.java
+++ b/util/src/main/java/org/killbill/billing/util/customfield/dao/DefaultCustomFieldDao.java
@@ -51,6 +51,7 @@ import org.killbill.billing.util.entity.dao.EntitySqlDao;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.bus.api.PersistentBus;
 import org.killbill.clock.Clock;
 import org.skife.jdbi.v2.IDBI;
@@ -69,12 +70,12 @@ public class DefaultCustomFieldDao extends EntityDaoBase<CustomFieldModelDao, Cu
 
     private static final Logger log = LoggerFactory.getLogger(DefaultCustomFieldDao.class);
 
-    private final PersistentBus bus;
+    private final BusOptimizer bus;
     private final AuditDao auditDao;
 
     @Inject
     public DefaultCustomFieldDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final Clock clock, final CacheControllerDispatcher controllerDispatcher,
-                                 final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory, final PersistentBus bus, final AuditDao auditDao) {
+                                 final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory, final BusOptimizer bus, final AuditDao auditDao) {
         super(nonEntityDao, controllerDispatcher, new EntitySqlDaoTransactionalJdbiWrapper(dbi, roDbi, clock, controllerDispatcher, nonEntityDao, internalCallContextFactory), CustomFieldSqlDao.class);
         this.bus = bus;
         this.auditDao = auditDao;

--- a/util/src/main/java/org/killbill/billing/util/glue/ConfigModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/ConfigModule.java
@@ -21,8 +21,11 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.tenant.api.TenantInternalApi.CacheInvalidationCallback;
 import org.killbill.billing.util.config.ConfigKillbillService;
 import org.killbill.billing.util.config.DefaultConfigKillbillService;
+import org.killbill.billing.util.config.definition.EventConfig;
+import org.killbill.billing.util.config.definition.MultiTenantEventConfig;
 import org.killbill.billing.util.config.tenant.CacheConfig;
 import org.killbill.billing.util.config.tenant.PerTenantConfigInvalidationCallback;
+import org.skife.config.ConfigurationObjectFactory;
 
 import com.google.inject.name.Names;
 
@@ -38,6 +41,11 @@ public class ConfigModule extends KillBillModule {
     protected void configure() {
         bind(CacheConfig.class).asEagerSingleton();
         bind(CacheInvalidationCallback.class).annotatedWith(Names.named(CONFIG_INVALIDATION_CALLBACK)).to(PerTenantConfigInvalidationCallback.class).asEagerSingleton();
-        bind(ConfigKillbillService.class).to(DefaultConfigKillbillService.class).asEagerSingleton();;
+        bind(ConfigKillbillService.class).to(DefaultConfigKillbillService.class).asEagerSingleton();
+
+        final EventConfig eventConfig = new ConfigurationObjectFactory(skifeConfigSource).build(EventConfig.class);
+        bind(EventConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(eventConfig);
+        bind(EventConfig.class).to(MultiTenantEventConfig.class).asEagerSingleton();
+
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/glue/EventModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/EventModule.java
@@ -1,6 +1,6 @@
 /*
- * Copyright 2014-2016 Groupon, Inc
- * Copyright 2014-2016 The Billing Project, LLC
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
  *
  * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the

--- a/util/src/main/java/org/killbill/billing/util/glue/EventModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/EventModule.java
@@ -29,18 +29,18 @@ import org.skife.config.ConfigurationObjectFactory;
 
 import com.google.inject.name.Names;
 
-public class ConfigModule extends KillBillModule {
+public class EventModule extends KillBillModule {
 
-    public static final String CONFIG_INVALIDATION_CALLBACK = "ConfigInvalidationCallback";
 
-    public ConfigModule(final KillbillConfigSource configSource) {
+    public EventModule(final KillbillConfigSource configSource) {
         super(configSource);
     }
 
     @Override
     protected void configure() {
-        bind(CacheConfig.class).asEagerSingleton();
-        bind(CacheInvalidationCallback.class).annotatedWith(Names.named(CONFIG_INVALIDATION_CALLBACK)).to(PerTenantConfigInvalidationCallback.class).asEagerSingleton();
-        bind(ConfigKillbillService.class).to(DefaultConfigKillbillService.class).asEagerSingleton();
+        final EventConfig eventConfig = new ConfigurationObjectFactory(skifeConfigSource).build(EventConfig.class);
+        bind(EventConfig.class).annotatedWith(Names.named(KillBillModule.STATIC_CONFIG)).toInstance(eventConfig);
+        bind(EventConfig.class).to(MultiTenantEventConfig.class).asEagerSingleton();
+
     }
 }

--- a/util/src/main/java/org/killbill/billing/util/glue/KillBillModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillBillModule.java
@@ -25,6 +25,8 @@ import com.google.inject.AbstractModule;
 
 public abstract class KillBillModule extends AbstractModule {
 
+    public static final String STATIC_CONFIG = "StaticConfig";
+
     protected final KillbillConfigSource configSource;
     protected final ConfigSource skifeConfigSource;
     protected final KillbillFeatures killbillFeatures;

--- a/util/src/main/java/org/killbill/billing/util/glue/KillBillShiroModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillBillShiroModule.java
@@ -44,10 +44,13 @@ import org.skife.config.ConfigurationObjectFactory;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.TypeLiteral;
 import com.google.inject.binder.AnnotatedBindingBuilder;
+import com.google.inject.name.Names;
 
 // For Kill Bill library only.
 // See org.killbill.billing.server.modules.KillBillShiroWebModule for Kill Bill server.
 public class KillBillShiroModule extends ShiroModule {
+
+    public static final String SHIRO_CACHE_MANAGER = "shiro";
 
     public static final String KILLBILL_LDAP_PROPERTY = "killbill.server.ldap";
     public static final String KILLBILL_OKTA_PROPERTY = "killbill.server.okta";
@@ -137,9 +140,9 @@ public class KillBillShiroModule extends ShiroModule {
 
         // Magic provider to configure the cache manager
         if (redisCacheConfig.isRedisCachingEnabled()) {
-            bind(CacheManager.class).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
         } else {
-            bind(CacheManager.class).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
         }
     }
 

--- a/util/src/main/java/org/killbill/billing/util/glue/KillBillShiroModule.java
+++ b/util/src/main/java/org/killbill/billing/util/glue/KillBillShiroModule.java
@@ -50,7 +50,6 @@ import com.google.inject.name.Names;
 // See org.killbill.billing.server.modules.KillBillShiroWebModule for Kill Bill server.
 public class KillBillShiroModule extends ShiroModule {
 
-    public static final String SHIRO_CACHE_MANAGER = "shiro";
 
     public static final String KILLBILL_LDAP_PROPERTY = "killbill.server.ldap";
     public static final String KILLBILL_OKTA_PROPERTY = "killbill.server.okta";
@@ -140,9 +139,9 @@ public class KillBillShiroModule extends ShiroModule {
 
         // Magic provider to configure the cache manager
         if (redisCacheConfig.isRedisCachingEnabled()) {
-            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).toProvider(RedisShiroManagerProvider.class).asEagerSingleton();
         } else {
-            bind(CacheManager.class).annotatedWith(Names.named(SHIRO_CACHE_MANAGER)).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
+            bind(CacheManager.class).toProvider(EhcacheShiroManagerProvider.class).asEagerSingleton();
         }
     }
 

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizer.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizer.java
@@ -17,8 +17,9 @@
 
 package org.killbill.billing.util.optimizer;
 
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.bus.api.BusEvent;
 
-public interface BusOptimizer extends PersistentBus {
+public interface BusDispatcherOptimizer {
+    boolean shouldDispatch(final BusEvent event);
 
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizerNoop.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizerNoop.java
@@ -17,8 +17,12 @@
 
 package org.killbill.billing.util.optimizer;
 
-import org.killbill.bus.api.PersistentBus;
+import org.killbill.bus.api.BusEvent;
 
-public interface BusOptimizer extends PersistentBus {
+public class BusDispatcherOptimizerNoop implements BusDispatcherOptimizer {
 
+    @Override
+    public boolean shouldDispatch(final BusEvent event) {
+        return true;
+    }
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizerOn.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.optimizer;
+
+import org.killbill.billing.callcontext.InternalCallContext;
+import org.killbill.billing.events.BusInternalEvent;
+import org.killbill.billing.util.callcontext.CallOrigin;
+import org.killbill.billing.util.callcontext.InternalCallContextFactory;
+import org.killbill.billing.util.callcontext.UserType;
+import org.killbill.billing.util.config.definition.EventConfig;
+import org.killbill.bus.api.BusEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+
+public class BusDispatcherOptimizerOn implements BusDispatcherOptimizer{
+
+    private static final Logger logger = LoggerFactory.getLogger(BusDispatcherOptimizerOn.class);
+
+    private final EventConfig eventConfig;
+    private final InternalCallContextFactory internalCallContextFactory;
+
+    @Inject
+    public BusDispatcherOptimizerOn(EventConfig eventConfig, final InternalCallContextFactory internalCallContextFactory) {
+        this.eventConfig = eventConfig;
+        this.internalCallContextFactory = internalCallContextFactory;
+    }
+
+    @Override
+    public boolean shouldDispatch(final BusEvent event) {
+        Preconditions.checkState(event instanceof BusInternalEvent, "Unexpected external bus event %s, skip...", event);
+        final BusInternalEvent internalEvent = (BusInternalEvent) event;
+
+        final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+        if (eventConfig.getSkipDispatchBusEventTypeList(context).contains(internalEvent.getBusEventType())) {
+            logger.debug("BusDispatcherOptimizerOn: Skip dispatching event {}", internalEvent.getBusEventType());
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusDispatcherOptimizerOn.java
@@ -51,9 +51,9 @@ public class BusDispatcherOptimizerOn implements BusDispatcherOptimizer{
         final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
         if (eventConfig.getSkipDispatchBusEventTypeList(context).contains(internalEvent.getBusEventType())) {
             logger.debug("BusDispatcherOptimizerOn: Skip dispatching event {}", internalEvent.getBusEventType());
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizer.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizer.java
@@ -17,8 +17,11 @@
 
 package org.killbill.billing.util.optimizer;
 
+import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.bus.api.PersistentBus;
 
 public interface BusOptimizer extends PersistentBus {
+
+    boolean shouldAggregateSubscriptionEvents(final InternalCallContext context);
 
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizer.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizer.java
@@ -17,7 +17,10 @@
 
 package org.killbill.billing.util.optimizer;
 
+import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.PersistentBus;
 
 public interface BusOptimizer extends PersistentBus {
+
+    boolean shouldDispatch(final BusEvent event);
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizer.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.optimizer;
+
+import org.killbill.bus.api.PersistentBus;
+
+public interface BusOptimizer extends PersistentBus {
+}

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.optimizer;
+
+import java.sql.Connection;
+
+import javax.inject.Inject;
+
+import org.joda.time.DateTime;
+import org.killbill.bus.api.BusEvent;
+import org.killbill.bus.api.BusEventWithMetadata;
+import org.killbill.bus.api.PersistentBus;
+
+public class BusOptimizerNoop implements BusOptimizer {
+
+    private final PersistentBus delegate;
+
+    @Inject
+    public BusOptimizerNoop(final PersistentBus eventBus) {
+        this.delegate = eventBus;
+    }
+
+    @Override
+    public void register(final Object handlerInstance) throws EventBusException {
+        delegate.register(handlerInstance);
+    }
+
+    @Override
+    public void unregister(final Object handlerInstance) throws EventBusException {
+        delegate.unregister(handlerInstance);
+    }
+
+    @Override
+    public void post(final BusEvent event) throws EventBusException {
+        delegate.post(event);
+    }
+
+    @Override
+    public void postFromTransaction(final BusEvent event, final Connection connection) throws EventBusException {
+        delegate.postFromTransaction(event, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsForSearchKeys(final Long searchKey1, final Long searchKey2) {
+        return delegate.getAvailableBusEventsForSearchKeys(searchKey1, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsFromTransactionForSearchKeys(final Long searchKey1, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableBusEventsFromTransactionForSearchKeys(searchKey1, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2) {
+        return delegate.getAvailableBusEventsForSearchKey2(maxCreatedDate, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsFromTransactionForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableBusEventsFromTransactionForSearchKey2(maxCreatedDate, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getInProcessingBusEvents() {
+        return delegate.getInProcessingBusEvents();
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsForSearchKeys(final Long searchKey1, final Long searchKey2) {
+        return delegate.getAvailableOrInProcessingBusEventsForSearchKeys(searchKey1, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsFromTransactionForSearchKeys(final Long searchKey1, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableOrInProcessingBusEventsFromTransactionForSearchKeys(searchKey1, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2) {
+        return delegate.getAvailableOrInProcessingBusEventsForSearchKey2(maxCreatedDate, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsFromTransactionForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableOrInProcessingBusEventsFromTransactionForSearchKey2(maxCreatedDate, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getHistoricalBusEventsForSearchKeys(final Long searchKey1, final Long searchKey2) {
+        return delegate.getHistoricalBusEventsForSearchKeys(searchKey1, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getHistoricalBusEventsForSearchKey2(final DateTime minCreatedDate, final Long searchKey2) {
+        return delegate.getHistoricalBusEventsForSearchKey2(minCreatedDate, searchKey2);
+    }
+
+    @Override
+    public long getNbReadyEntries(final DateTime maxCreatedDate) {
+        return delegate.getNbReadyEntries(maxCreatedDate);
+    }
+
+    @Override
+    public boolean initQueue() {
+        return delegate.initQueue();
+    }
+
+    @Override
+    public boolean startQueue() {
+        return delegate.startQueue();
+    }
+
+    @Override
+    public void stopQueue() {
+        delegate.stopQueue();
+    }
+
+    @Override
+    public boolean isStarted() {
+        return delegate.isStarted();
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
@@ -22,6 +22,7 @@ import java.sql.Connection;
 import javax.inject.Inject;
 
 import org.joda.time.DateTime;
+import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.BusEventWithMetadata;
 import org.killbill.bus.api.PersistentBus;
@@ -135,4 +136,8 @@ public class BusOptimizerNoop implements BusOptimizer {
         return delegate.isStarted();
     }
 
+    @Override
+    public boolean shouldAggregateSubscriptionEvents(final InternalCallContext context) {
+        return false;
+    }
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
@@ -135,8 +135,4 @@ public class BusOptimizerNoop implements BusOptimizer {
         return delegate.isStarted();
     }
 
-    @Override
-    public boolean shouldDispatch(final BusEvent event) {
-        return true;
-    }
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerNoop.java
@@ -134,4 +134,9 @@ public class BusOptimizerNoop implements BusOptimizer {
     public boolean isStarted() {
         return delegate.isStarted();
     }
+
+    @Override
+    public boolean shouldDispatch(final BusEvent event) {
+        return true;
+    }
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
@@ -169,16 +169,4 @@ public class BusOptimizerOn implements BusOptimizer {
         return delegate.isStarted();
     }
 
-    @Override
-    public boolean shouldDispatch(final BusEvent event) {
-        Preconditions.checkState(event instanceof BusInternalEvent, "Unexpected external bus event %s, skip...", event);
-        final BusInternalEvent internalEvent = (BusInternalEvent) event;
-
-        final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-        if (eventConfig.getSkipDispatchBusEventTypeList(context).contains(internalEvent.getBusEventType())) {
-            logger.debug("BusOptimizerOn: Skip dispatching event {}", internalEvent.getBusEventType());
-            return true;
-        }
-        return false;
-    }
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
@@ -65,7 +65,7 @@ public class BusOptimizerOn implements BusOptimizer {
     private boolean shouldSkip(final BusEvent event) {
         Preconditions.checkState(event instanceof BusInternalEvent, "Unexpected external bus event %s, skip...", event);
         final BusInternalEvent internalEvent = (BusInternalEvent) event;
-        final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+        final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
         if (eventConfig.getSkipPostBusEventTypeList(context).contains(internalEvent.getBusEventType())) {
             logger.debug("BusOptimizerOn: Skip sending event {}", internalEvent.getBusEventType());
             return true;
@@ -174,7 +174,7 @@ public class BusOptimizerOn implements BusOptimizer {
         Preconditions.checkState(event instanceof BusInternalEvent, "Unexpected external bus event %s, skip...", event);
         final BusInternalEvent internalEvent = (BusInternalEvent) event;
 
-        final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+        final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
         if (eventConfig.getSkipDispatchBusEventTypeList(context).contains(internalEvent.getBusEventType())) {
             logger.debug("BusOptimizerOn: Skip dispatching event {}", internalEvent.getBusEventType());
             return true;

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
@@ -22,6 +22,7 @@ import java.sql.Connection;
 import javax.inject.Inject;
 
 import org.joda.time.DateTime;
+import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.events.BusInternalEvent;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
 import org.killbill.billing.util.config.definition.EventConfig;
@@ -64,7 +65,7 @@ public class BusOptimizerOn implements BusOptimizer {
         final BusInternalEvent internalEvent = (BusInternalEvent) event;
         //
         // TODO haha... Unfortunately for 'postFromTransaction' this may break as we enter with an open transaction:
-        // If we need to to read the per-context multi-tenant config, this requires another call to the DB which then breaks...
+        // If we need to read the per-context multi-tenant config, this requires another call to the DB which then breaks...
         //
 
         //final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
@@ -171,4 +172,8 @@ public class BusOptimizerOn implements BusOptimizer {
         return delegate.isStarted();
     }
 
+    @Override
+    public boolean shouldAggregateSubscriptionEvents(final InternalCallContext context) {
+        return eventConfig.isAggregateBulkSubscriptionEvents(context);
+    }
 }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2020-2021 Equinix, Inc
+ * Copyright 2014-2021 The Billing Project, LLC
+ *
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.killbill.billing.util.optimizer;
+
+import java.sql.Connection;
+
+import javax.inject.Inject;
+
+import org.joda.time.DateTime;
+import org.killbill.billing.events.BusInternalEvent;
+import org.killbill.billing.util.config.definition.EventConfig;
+import org.killbill.bus.api.BusEvent;
+import org.killbill.bus.api.BusEventWithMetadata;
+import org.killbill.bus.api.PersistentBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+public class BusOptimizerOn implements BusOptimizer {
+
+    private static final Logger logger = LoggerFactory.getLogger(BusOptimizerOn.class);
+
+    private final PersistentBus delegate;
+    private final EventConfig eventConfig;
+
+    @Inject
+    public BusOptimizerOn(final PersistentBus eventBus, final EventConfig eventConfig) {
+        this.delegate = eventBus;
+        this.eventConfig = eventConfig;
+        logger.info("Feature BusOptimizerOn is ON");
+    }
+
+    @Override
+    public void register(final Object handlerInstance) throws EventBusException {
+        delegate.register(handlerInstance);
+    }
+
+    @Override
+    public void unregister(final Object handlerInstance) throws EventBusException {
+        delegate.unregister(handlerInstance);
+    }
+
+    private boolean shouldSkip(final BusEvent event) {
+        Preconditions.checkState(event instanceof BusInternalEvent, "Unexpected external bus event %s, skip...", event);
+        final BusInternalEvent internalEvent = (BusInternalEvent) event;
+
+        if (eventConfig.getSkipPostBusEventTypeList().contains(internalEvent.getBusEventType())) {
+            logger.info("BusOptimizerOn: Skip sending event {}", internalEvent.getBusEventType());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void post(final BusEvent event) throws EventBusException {
+        if (shouldSkip(event)) {
+            return;
+        }
+        delegate.post(event);
+    }
+
+    @Override
+    public void postFromTransaction(final BusEvent event, final Connection connection) throws EventBusException {
+        if (shouldSkip(event)) {
+            return;
+        }
+        delegate.postFromTransaction(event, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsForSearchKeys(final Long searchKey1, final Long searchKey2) {
+        return delegate.getAvailableBusEventsForSearchKeys(searchKey1, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsFromTransactionForSearchKeys(final Long searchKey1, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableBusEventsFromTransactionForSearchKeys(searchKey1, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2) {
+        return delegate.getAvailableBusEventsForSearchKey2(maxCreatedDate, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableBusEventsFromTransactionForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableBusEventsFromTransactionForSearchKey2(maxCreatedDate, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getInProcessingBusEvents() {
+        return delegate.getInProcessingBusEvents();
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsForSearchKeys(final Long searchKey1, final Long searchKey2) {
+        return delegate.getAvailableOrInProcessingBusEventsForSearchKeys(searchKey1, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsFromTransactionForSearchKeys(final Long searchKey1, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableOrInProcessingBusEventsFromTransactionForSearchKeys(searchKey1, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2) {
+        return delegate.getAvailableOrInProcessingBusEventsForSearchKey2(maxCreatedDate, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getAvailableOrInProcessingBusEventsFromTransactionForSearchKey2(final DateTime maxCreatedDate, final Long searchKey2, final Connection connection) {
+        return delegate.getAvailableOrInProcessingBusEventsFromTransactionForSearchKey2(maxCreatedDate, searchKey2, connection);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getHistoricalBusEventsForSearchKeys(final Long searchKey1, final Long searchKey2) {
+        return delegate.getHistoricalBusEventsForSearchKeys(searchKey1, searchKey2);
+    }
+
+    @Override
+    public <T extends BusEvent> Iterable<BusEventWithMetadata<T>> getHistoricalBusEventsForSearchKey2(final DateTime minCreatedDate, final Long searchKey2) {
+        return delegate.getHistoricalBusEventsForSearchKey2(minCreatedDate, searchKey2);
+    }
+
+    @Override
+    public long getNbReadyEntries(final DateTime maxCreatedDate) {
+        return delegate.getNbReadyEntries(maxCreatedDate);
+    }
+
+    @Override
+    public boolean initQueue() {
+        return delegate.initQueue();
+    }
+
+    @Override
+    public boolean startQueue() {
+        return delegate.startQueue();
+    }
+
+    @Override
+    public void stopQueue() {
+        delegate.stopQueue();
+    }
+
+    @Override
+    public boolean isStarted() {
+        return delegate.isStarted();
+    }
+}

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
@@ -65,8 +65,13 @@ public class BusOptimizerOn implements BusOptimizer {
     private boolean shouldSkip(final BusEvent event) {
         Preconditions.checkState(event instanceof BusInternalEvent, "Unexpected external bus event %s, skip...", event);
         final BusInternalEvent internalEvent = (BusInternalEvent) event;
-        final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
-        if (eventConfig.getSkipPostBusEventTypeList(context).contains(internalEvent.getBusEventType())) {
+        //
+        // TODO haha... Unfortunately for 'postFromTransaction' this may break as we enter with an open transaction:
+        // If we need to to read the per-context multi-tenant config, this requires another call to the DB which then breaks...
+        //
+
+        //final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), null, "BusOptimizerOn", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
+        if (eventConfig.getSkipPostBusEventTypeList(/*context*/).contains(internalEvent.getBusEventType())) {
             logger.debug("BusOptimizerOn: Skip sending event {}", internalEvent.getBusEventType());
             return true;
         }

--- a/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
+++ b/util/src/main/java/org/killbill/billing/util/optimizer/BusOptimizerOn.java
@@ -22,11 +22,8 @@ import java.sql.Connection;
 import javax.inject.Inject;
 
 import org.joda.time.DateTime;
-import org.killbill.billing.callcontext.InternalCallContext;
 import org.killbill.billing.events.BusInternalEvent;
-import org.killbill.billing.util.callcontext.CallOrigin;
 import org.killbill.billing.util.callcontext.InternalCallContextFactory;
-import org.killbill.billing.util.callcontext.UserType;
 import org.killbill.billing.util.config.definition.EventConfig;
 import org.killbill.bus.api.BusEvent;
 import org.killbill.bus.api.BusEventWithMetadata;

--- a/util/src/main/java/org/killbill/billing/util/tag/dao/DefaultTagDao.java
+++ b/util/src/main/java/org/killbill/billing/util/tag/dao/DefaultTagDao.java
@@ -47,6 +47,7 @@ import org.killbill.billing.util.entity.dao.EntitySqlDao;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.tag.ControlTagType;
 import org.killbill.billing.util.tag.Tag;
 import org.killbill.billing.util.tag.api.user.TagEventBuilder;
@@ -69,11 +70,11 @@ public class DefaultTagDao extends EntityDaoBase<TagModelDao, Tag, TagApiExcepti
     private static final Logger log = LoggerFactory.getLogger(DefaultTagDao.class);
 
     private final TagEventBuilder tagEventBuilder;
-    private final PersistentBus bus;
+    private final BusOptimizer bus;
     private final AuditDao auditDao;
 
     @Inject
-    public DefaultTagDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final TagEventBuilder tagEventBuilder, final PersistentBus bus, final Clock clock,
+    public DefaultTagDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final TagEventBuilder tagEventBuilder, final BusOptimizer bus, final Clock clock,
                          final CacheControllerDispatcher controllerDispatcher, final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory, final AuditDao auditDao) {
         super(nonEntityDao, controllerDispatcher, new EntitySqlDaoTransactionalJdbiWrapper(dbi, roDbi, clock, controllerDispatcher, nonEntityDao, internalCallContextFactory), TagSqlDao.class);
         this.tagEventBuilder = tagEventBuilder;

--- a/util/src/main/java/org/killbill/billing/util/tag/dao/DefaultTagDefinitionDao.java
+++ b/util/src/main/java/org/killbill/billing/util/tag/dao/DefaultTagDefinitionDao.java
@@ -44,6 +44,7 @@ import org.killbill.billing.util.entity.dao.EntityDaoBase;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoTransactionalJdbiWrapper;
 import org.killbill.billing.util.entity.dao.EntitySqlDaoWrapperFactory;
+import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.tag.TagDefinition;
 import org.killbill.billing.util.tag.api.user.TagEventBuilder;
 import org.killbill.bus.api.PersistentBus;
@@ -65,11 +66,11 @@ public class DefaultTagDefinitionDao extends EntityDaoBase<TagDefinitionModelDao
     private static final Logger log = LoggerFactory.getLogger(DefaultTagDefinitionDao.class);
 
     private final TagEventBuilder tagEventBuilder;
-    private final PersistentBus bus;
+    private final BusOptimizer bus;
     private final AuditDao auditDao;
 
     @Inject
-    public DefaultTagDefinitionDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final TagEventBuilder tagEventBuilder, final PersistentBus bus, final Clock clock,
+    public DefaultTagDefinitionDao(final IDBI dbi, @Named(MAIN_RO_IDBI_NAMED) final IDBI roDbi, final TagEventBuilder tagEventBuilder, final BusOptimizer bus, final Clock clock,
                                    final CacheControllerDispatcher controllerDispatcher, final NonEntityDao nonEntityDao, final InternalCallContextFactory internalCallContextFactory, final AuditDao auditDao) {
         super(nonEntityDao, controllerDispatcher, new EntitySqlDaoTransactionalJdbiWrapper(dbi, roDbi, clock, controllerDispatcher, nonEntityDao, internalCallContextFactory), TagDefinitionSqlDao.class);
         this.tagEventBuilder = tagEventBuilder;

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestNoDBModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestNoDBModule.java
@@ -22,6 +22,8 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.platform.test.glue.TestPlatformModuleNoDB;
 import org.killbill.billing.util.glue.IDBISetup;
 import org.killbill.billing.util.glue.MemoryGlobalLockerModule;
+import org.killbill.billing.util.optimizer.BusOptimizer;
+import org.killbill.billing.util.optimizer.BusOptimizerNoop;
 import org.killbill.clock.ClockMock;
 import org.skife.jdbi.v2.IDBI;
 
@@ -35,11 +37,24 @@ public class GuicyKillbillTestNoDBModule extends GuicyKillbillTestModule {
         super(configSource, clock);
     }
 
+    public class KillbillTestPlatformModuleNoDB extends TestPlatformModuleNoDB {
+
+        public KillbillTestPlatformModuleNoDB(final KillbillConfigSource configSource) {
+            super(configSource);
+        }
+
+        @Override
+        protected void configureBus() {
+            super.configureBus();
+            this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+        }
+    }
+
     @Override
     protected void configure() {
         super.configure();
 
-        install(new TestPlatformModuleNoDB(configSource));
+        install(new KillbillTestPlatformModuleNoDB(configSource));
         install(new MemoryGlobalLockerModule(configSource));
     }
 

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestNoDBModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestNoDBModule.java
@@ -22,6 +22,9 @@ import org.killbill.billing.platform.api.KillbillConfigSource;
 import org.killbill.billing.platform.test.glue.TestPlatformModuleNoDB;
 import org.killbill.billing.util.glue.IDBISetup;
 import org.killbill.billing.util.glue.MemoryGlobalLockerModule;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizerNoop;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizerOn;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.optimizer.BusOptimizerNoop;
 import org.killbill.billing.util.optimizer.BusOptimizerOn;
@@ -49,8 +52,10 @@ public class GuicyKillbillTestNoDBModule extends GuicyKillbillTestModule {
             super.configureBus();
             if (killbillFeatures.isBusOptimizationOn()) {
                 this.bind(BusOptimizer.class).to(BusOptimizerOn.class).asEagerSingleton();
+                this.bind(BusDispatcherOptimizer.class).to(BusDispatcherOptimizerOn.class).asEagerSingleton();
             } else {
                 this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+                this.bind(BusDispatcherOptimizer.class).to(BusDispatcherOptimizerNoop.class).asEagerSingleton();
             }
         }
     }

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestNoDBModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestNoDBModule.java
@@ -24,6 +24,7 @@ import org.killbill.billing.util.glue.IDBISetup;
 import org.killbill.billing.util.glue.MemoryGlobalLockerModule;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.optimizer.BusOptimizerNoop;
+import org.killbill.billing.util.optimizer.BusOptimizerOn;
 import org.killbill.clock.ClockMock;
 import org.skife.jdbi.v2.IDBI;
 
@@ -46,7 +47,11 @@ public class GuicyKillbillTestNoDBModule extends GuicyKillbillTestModule {
         @Override
         protected void configureBus() {
             super.configureBus();
-            this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+            if (killbillFeatures.isBusOptimizationOn()) {
+                this.bind(BusOptimizer.class).to(BusOptimizerOn.class).asEagerSingleton();
+            } else {
+                this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+            }
         }
     }
 

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
@@ -26,6 +26,7 @@ import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.IDBISetup;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.optimizer.BusOptimizerNoop;
+import org.killbill.billing.util.optimizer.BusOptimizerOn;
 import org.killbill.clock.ClockMock;
 import org.skife.jdbi.v2.IDBI;
 
@@ -70,7 +71,11 @@ public class GuicyKillbillTestWithEmbeddedDBModule extends GuicyKillbillTestModu
         @Override
         protected void configureBus() {
             super.configureBus();
-            this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+            if (killbillFeatures.isBusOptimizationOn()) {
+                this.bind(BusOptimizer.class).to(BusOptimizerOn.class).asEagerSingleton();
+            } else {
+                this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+            }
         }
 
         @Override

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
@@ -24,6 +24,8 @@ import org.killbill.billing.platform.test.config.TestKillbillConfigSource;
 import org.killbill.billing.platform.test.glue.TestPlatformModuleWithEmbeddedDB;
 import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.IDBISetup;
+import org.killbill.billing.util.optimizer.BusOptimizer;
+import org.killbill.billing.util.optimizer.BusOptimizerNoop;
 import org.killbill.clock.ClockMock;
 import org.skife.jdbi.v2.IDBI;
 
@@ -63,6 +65,12 @@ public class GuicyKillbillTestWithEmbeddedDBModule extends GuicyKillbillTestModu
         @Named(IDBISetup.MAIN_RO_IDBI_NAMED)
         protected IDBI provideRoIDBIInAComplicatedWayBecauseOf627(final IDBI idbi) {
             return idbi;
+        }
+
+        @Override
+        protected void configureBus() {
+            super.configureBus();
+            this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
         }
 
         @Override

--- a/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
+++ b/util/src/test/java/org/killbill/billing/GuicyKillbillTestWithEmbeddedDBModule.java
@@ -24,6 +24,9 @@ import org.killbill.billing.platform.test.config.TestKillbillConfigSource;
 import org.killbill.billing.platform.test.glue.TestPlatformModuleWithEmbeddedDB;
 import org.killbill.billing.util.glue.GlobalLockerModule;
 import org.killbill.billing.util.glue.IDBISetup;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizer;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizerNoop;
+import org.killbill.billing.util.optimizer.BusDispatcherOptimizerOn;
 import org.killbill.billing.util.optimizer.BusOptimizer;
 import org.killbill.billing.util.optimizer.BusOptimizerNoop;
 import org.killbill.billing.util.optimizer.BusOptimizerOn;
@@ -73,8 +76,10 @@ public class GuicyKillbillTestWithEmbeddedDBModule extends GuicyKillbillTestModu
             super.configureBus();
             if (killbillFeatures.isBusOptimizationOn()) {
                 this.bind(BusOptimizer.class).to(BusOptimizerOn.class).asEagerSingleton();
+                this.bind(BusDispatcherOptimizer.class).to(BusDispatcherOptimizerOn.class).asEagerSingleton();
             } else {
                 this.bind(BusOptimizer.class).to(BusOptimizerNoop.class).asEagerSingleton();
+                this.bind(BusDispatcherOptimizer.class).to(BusDispatcherOptimizerNoop.class).asEagerSingleton();
             }
         }
 

--- a/util/src/test/java/org/killbill/billing/util/glue/TestUtilModule.java
+++ b/util/src/test/java/org/killbill/billing/util/glue/TestUtilModule.java
@@ -43,6 +43,7 @@ public class TestUtilModule extends KillBillModule {
         //install(new CallContextModule());
         install(new CacheModule(configSource));
         install(new ConfigModule(configSource));
+        install(new EventModule(configSource));
         install(new MockTenantModule(configSource));
         installHacks();
     }


### PR DESCRIPTION
This PR introduces a new feature flag, which when enabled provides additional control for when (internal) bus event delivery 
 & dispatching occurs.

The setting for which bus events are being sent/received occurs through normal configuration and supports per-tenant configuration:

* Ability to control which event to post
* Ability to enable/disable KB internal handlers on a per `BusInternalEvent`
* Ability to aggregate events for bulk subscription calls (No aggregation is provided for notification events)
 
TODO: Per-tenant configuration on `post` is currently broken (and may be difficult to fix)
