### PR TITLE
Perf improvements around for bulk subscription creation

### DIFF
--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestSubscription.java
@@ -230,9 +230,6 @@ public class TestSubscription extends TestIntegrationBase {
                                       NextEvent.CREATE, NextEvent.BLOCK,
                                       NextEvent.CREATE, NextEvent.BLOCK,
                                       NextEvent.CREATE, NextEvent.BLOCK,
-                                      NextEvent.NULL_INVOICE, NextEvent.NULL_INVOICE,
-                                      NextEvent.NULL_INVOICE, NextEvent.NULL_INVOICE,
-                                      NextEvent.NULL_INVOICE,
                                       NextEvent.INVOICE,
                                       NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT
                                      );
@@ -314,8 +311,6 @@ public class TestSubscription extends TestIntegrationBase {
                                       NextEvent.CREATE, NextEvent.BLOCK,
                                       NextEvent.CREATE, NextEvent.BLOCK,
                                       NextEvent.CREATE, NextEvent.BLOCK,
-                                      NextEvent.NULL_INVOICE, NextEvent.NULL_INVOICE,
-                                      NextEvent.NULL_INVOICE, NextEvent.NULL_INVOICE,
                                       NextEvent.INVOICE,
                                       NextEvent.PAYMENT, NextEvent.INVOICE_PAYMENT
                                      );

--- a/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithBCDUpdate.java
+++ b/beatrix/src/test/java/org/killbill/billing/beatrix/integration/TestWithBCDUpdate.java
@@ -764,7 +764,7 @@ public class TestWithBCDUpdate extends TestIntegrationBase {
         final PlanPhaseSpecifier spec = new PlanPhaseSpecifier("pistol-monthly-notrial");
 
 
-        busHandler.pushExpectedEvents( NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        busHandler.pushExpectedEvents( NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
 
         // We will realign the BCD on the 15 as we create the subscription - ignoring the account setting on 21.
         final UUID entitlementId = entitlementApi.createBaseEntitlement(account.getId(), new DefaultEntitlementSpecifier(spec, 15, null, null), null, null, null, false, false, ImmutableList.<PluginProperty>of(), callContext);
@@ -893,7 +893,7 @@ public class TestWithBCDUpdate extends TestIntegrationBase {
         overrides.add(new DefaultPlanPhasePriceOverride("blowdart-quarterly-notrial-evergreen", account.getCurrency(), BigDecimal.TEN, BigDecimal.ZERO, ImmutableList.<UsagePriceOverride>of()));
         final DefaultEntitlementSpecifier entitlementSpecifier = new DefaultEntitlementSpecifier(spec, billCycleDay, UUID.randomUUID().toString(), overrides);
 
-        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.NULL_INVOICE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
+        busHandler.pushExpectedEvents(NextEvent.CREATE, NextEvent.BLOCK, NextEvent.BCD_CHANGE, NextEvent.INVOICE, NextEvent.INVOICE_PAYMENT, NextEvent.PAYMENT);
         entitlementApi.createBaseEntitlement(account.getId(), entitlementSpecifier, "134582864", null, null, false, true, ImmutableList.<PluginProperty>of(), callContext);
         assertListenerStatus();
 

--- a/entitlement/src/main/java/org/killbill/billing/entitlement/logging/EntitlementLoggingHelper.java
+++ b/entitlement/src/main/java/org/killbill/billing/entitlement/logging/EntitlementLoggingHelper.java
@@ -33,6 +33,20 @@ import org.slf4j.Logger;
 
 public abstract class EntitlementLoggingHelper {
 
+    private static final int MAX_LENGTH = 1024;
+
+    private static void logWithLimit(final Logger log, final String line) {
+        final String logLine;
+        if (line.length() >  MAX_LENGTH) {
+            final StringBuilder tmp = new StringBuilder(line.substring(0, MAX_LENGTH));
+            tmp.append("...");
+            logLine = tmp.toString();
+        } else {
+            logLine = line;
+        }
+        log.info(logLine);
+    }
+
     public static void logCreateEntitlementsWithAOs(final Logger log, final Iterable<BaseEntitlementWithAddOnsSpecifier> baseEntitlementSpecifiersWithAddOns) {
         if (log.isInfoEnabled()) {
             final StringBuilder logLine = new StringBuilder("Create Entitlements with AddOns: ");
@@ -46,7 +60,7 @@ public abstract class EntitlementLoggingHelper {
                                                 cur.getBillingEffectiveDate());
                 }
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -102,7 +116,7 @@ public abstract class EntitlementLoggingHelper {
                        .append(effectiveDate)
                        .append("'");
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -140,7 +154,7 @@ public abstract class EntitlementLoggingHelper {
                        .append(billingPolicy)
                        .append("'");
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -170,7 +184,7 @@ public abstract class EntitlementLoggingHelper {
                        .append(billingPolicy)
                        .append("'");
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -180,7 +194,7 @@ public abstract class EntitlementLoggingHelper {
                     .append(" id = '")
                     .append(entitlement.getId())
                     .append("'");
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -190,7 +204,7 @@ public abstract class EntitlementLoggingHelper {
                     .append(" id = '")
                     .append(entitlement.getId())
                     .append("'");
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -235,7 +249,7 @@ public abstract class EntitlementLoggingHelper {
                            .append("'");
                 }
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -254,7 +268,7 @@ public abstract class EntitlementLoggingHelper {
                        .append(effectiveFromDate)
                        .append("'");
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -271,7 +285,7 @@ public abstract class EntitlementLoggingHelper {
                        .append(newExternalKey)
                        .append("'");
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 
@@ -284,7 +298,7 @@ public abstract class EntitlementLoggingHelper {
                        .append(inputEffectiveDate)
                        .append("'");
             }
-            log.info(logLine.toString());
+            logWithLimit(log, logLine.toString());
         }
     }
 

--- a/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
+++ b/invoice/src/main/java/org/killbill/billing/invoice/InvoiceListener.java
@@ -166,6 +166,12 @@ public class InvoiceListener extends RetryableService implements InvoiceListener
                                          new SubscriberAction<RequestedSubscriptionInternalEvent>() {
                                              @Override
                                              public void run(final RequestedSubscriptionInternalEvent event) {
+
+                                                 if (event.getRemainingEventsForUserOperation() > 0) {
+                                                     return;
+                                                 }
+
+
                                                  final InternalCallContext context = internalCallContextFactory.createInternalCallContext(event.getSearchKey2(), event.getSearchKey1(), "SubscriptionBaseTransition", CallOrigin.INTERNAL, UserType.SYSTEM, event.getUserToken());
                                                  dispatcher.processSubscriptionStartRequestedDate(event, context);
                                              }

--- a/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/Obfuscator.java
+++ b/profiles/killbill/src/main/java/org/killbill/billing/server/log/obfuscators/Obfuscator.java
@@ -30,7 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 public abstract class Obfuscator {
 
     @VisibleForTesting
-    static final String LOGGING_FILTER_NAME = "com.sun.jersey.api.container.filter.LoggingFilter";
+    static final String LOGGING_FILTER_NAME = "org.glassfish.jersey.logging.LoggingFeature";
 
     protected static final int DEFAULT_PATTERN_FLAGS = Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.DOTALL;
 

--- a/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultRequestedSubscriptionEvent.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/api/user/DefaultRequestedSubscriptionEvent.java
@@ -62,10 +62,11 @@ public class DefaultRequestedSubscriptionEvent extends DefaultSubscriptionEvent 
     public DefaultRequestedSubscriptionEvent(final DefaultSubscriptionBase subscription,
                                              final SubscriptionBaseEvent nextEvent,
                                              final SubscriptionBaseTransitionType transitionType,
+                                             final Integer remainingEventsForUserOperation,
                                              final Long searchKey1,
                                              final Long searchKey2,
                                              final UUID userToken) {
         this(nextEvent.getId(), nextEvent.getSubscriptionId(), subscription.getBundleId(), subscription.getBundleExternalKey(), nextEvent.getEffectiveDate(), nextEvent.getEffectiveDate(),
-             null, null, null, null, null, null, null, null, null, null, nextEvent.getTotalOrdering(), transitionType, 0, null, searchKey1, searchKey2, userToken);
+             null, null, null, null, null, null, null, null, null, null, nextEvent.getTotalOrdering(), transitionType, remainingEventsForUserOperation, null, searchKey1, searchKey2, userToken);
     }
 }

--- a/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
+++ b/subscription/src/main/java/org/killbill/billing/subscription/engine/dao/DefaultSubscriptionDao.java
@@ -606,7 +606,7 @@ public class DefaultSubscriptionDao extends EntityDaoBase<SubscriptionBundleMode
                         for (final SubscriptionBaseEvent cur : initialEvents) {
                             createdEvents.add(createAndRefresh(eventsDaoFromSameTransaction, new SubscriptionEventModelDao(cur), context));
 
-                            final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER);
+                            final boolean isBusEvent = cur.getEffectiveDate().compareTo(context.getCreatedDate()) <= 0 && (cur.getType() == EventType.API_USER || cur.getType() == EventType.BCD_UPDATE);
                             final int seqId = isBusEvent ? busEffSeqId++ : 0;
                             recordBusOrFutureNotificationFromTransaction(defaultSubscriptionBase, cur, entitySqlDaoWrapperFactory, isBusEvent, seqId, catalog, context);
                         }


### PR DESCRIPTION
This is a PR on top of `https://github.com/sbrossie/killbill/pull/1` to include small efficiency fixes mostly in the path of bulk subscription creation.

Also includes a big fix in https://github.com/sbrossie/killbill/pull/2/commits/de2abd186ca9ff6d6646ed328af6f7ca1fc0b4d8 for correctly returning profile json.

Additional areas of improvements (not done):
* Optimize code to not fetch *subscription state* (incl. subscription base + blocking state) by account recordId (could be based on a setting, or a quick detection of many subscriptions there are for the account)
* Known Limitations to Scalability:
  * `invoice_billing_events#billing_events` is defined as a blob (mysql -> 64k), knowing that info is gzipped
  * `NextBillingDateNotificationKey#uuidkeys` may overflow with too many subscriptions
  